### PR TITLE
Fix GetInstance method to properly work on real Kubernetes cluster 

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -109,4 +109,5 @@ func configHandlers(e *echo.Echo) {
 	e.POST("/resources/:instance/scale", scale)
 	e.POST("/resources/:instance/certificate", updateCertificate)
 	e.POST("/resources/:instance/block", updateBlock)
+	e.DELETE("/resources/:instance/block/:block", deleteBlock)
 }

--- a/api/api.go
+++ b/api/api.go
@@ -108,6 +108,7 @@ func configHandlers(e *echo.Echo) {
 
 	e.POST("/resources/:instance/scale", scale)
 	e.POST("/resources/:instance/certificate", updateCertificate)
+	e.GET("/resources/:instance/block", listBlocks)
 	e.POST("/resources/:instance/block", updateBlock)
 	e.DELETE("/resources/:instance/block/:block", deleteBlock)
 }

--- a/api/api.go
+++ b/api/api.go
@@ -108,4 +108,5 @@ func configHandlers(e *echo.Echo) {
 
 	e.POST("/resources/:instance/scale", scale)
 	e.POST("/resources/:instance/certificate", updateCertificate)
+	e.POST("/resources/:instance/block", updateBlock)
 }

--- a/api/blocks.go
+++ b/api/blocks.go
@@ -8,6 +8,25 @@ import (
 	"github.com/tsuru/rpaas-operator/rpaas"
 )
 
+func deleteBlock(c echo.Context) error {
+	manager, err := getManager(c)
+	if err != nil {
+		return err
+	}
+	block := c.Param("block")
+	err = manager.DeleteBlock(c.Param("instance"), block)
+	switch err {
+	case nil:
+		return c.String(http.StatusOK, fmt.Sprintf("block %q was successfully removed", block))
+	case rpaas.ErrBlockInvalid:
+		return c.String(http.StatusBadRequest, fmt.Sprintf("%s", err))
+	case rpaas.ErrBlockIsNotDefined:
+		return c.NoContent(http.StatusNoContent)
+	default:
+		return err
+	}
+}
+
 func updateBlock(c echo.Context) error {
 	manager, err := getManager(c)
 	if err != nil {

--- a/api/blocks.go
+++ b/api/blocks.go
@@ -8,6 +8,11 @@ import (
 	"github.com/tsuru/rpaas-operator/rpaas"
 )
 
+type Block struct {
+	Name    string `form:"block_name" json:"block_name"`
+	Content string `form:"content" json:"content"`
+}
+
 func deleteBlock(c echo.Context) error {
 	manager, err := getManager(c)
 	if err != nil {
@@ -27,15 +32,34 @@ func deleteBlock(c echo.Context) error {
 	}
 }
 
+func listBlocks(c echo.Context) error {
+	manager, err := getManager(c)
+	if err != nil {
+		return err
+	}
+	blocks, err := manager.ListBlocks(c.Param("instance"))
+	if err != nil {
+		return err
+	}
+	result := struct {
+		Blocks []Block `json:"blocks"`
+	}{
+		Blocks: make([]Block, len(blocks)),
+	}
+	var index int
+	for name, content := range blocks {
+		result.Blocks[index] = Block{Name: name, Content: content}
+		index++
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
 func updateBlock(c echo.Context) error {
 	manager, err := getManager(c)
 	if err != nil {
 		return err
 	}
-	data := struct {
-		Name    string `form:"block_name"`
-		Content string `form:"content"`
-	}{}
+	var data Block
 	if err = c.Bind(&data); err != nil {
 		return err
 	}

--- a/api/blocks.go
+++ b/api/blocks.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo"
+	"github.com/tsuru/rpaas-operator/rpaas"
+)
+
+func updateBlock(c echo.Context) error {
+	manager, err := getManager(c)
+	if err != nil {
+		return err
+	}
+	data := struct {
+		Name    string `form:"block_name"`
+		Content string `form:"content"`
+	}{}
+	if err = c.Bind(&data); err != nil {
+		return err
+	}
+	err = manager.UpdateBlock(c.Param("instance"), data.Name, data.Content)
+	switch err {
+	case nil:
+		return c.NoContent(http.StatusCreated)
+	case rpaas.ErrBlockInvalid:
+		return c.String(http.StatusBadRequest, fmt.Sprintf("%s", err))
+	default:
+		return err
+	}
+}

--- a/api/blocks_test.go
+++ b/api/blocks_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+	"github.com/tsuru/rpaas-operator/rpaas"
+	"github.com/tsuru/rpaas-operator/rpaas/fake"
+)
+
+func Test_updateBlock(t *testing.T) {
+	instanceName := "my-instance"
+
+	testCases := []struct {
+		requestBody   string
+		expectedCode  int
+		expectedBody  string
+		expectedError error
+		manager       rpaas.RpaasManager
+	}{
+		{
+			"",
+			http.StatusBadRequest,
+			fmt.Sprintf("{\"message\":\"Request body can't be empty\"}\n"),
+			echo.NewHTTPError(http.StatusBadRequest, "Request body can't be empty"),
+			&fake.RpaasManager{},
+		},
+		{
+			"block_name=invalid-block&content=",
+			http.StatusBadRequest,
+			`rpaas: block is not valid (acceptable values are: [root http server])`,
+			nil,
+			&fake.RpaasManager{
+				FakeUpdateBlock: func(i, b, c string) error {
+					return rpaas.ErrBlockInvalid
+				},
+			},
+		},
+		{
+			"block_name=server&content=%23%20My%20nginx%20custom%20conf",
+			http.StatusCreated,
+			"",
+			nil,
+			&fake.RpaasManager{},
+		},
+		{
+			"block_name=server&content=%23%20My%20nginx%20custom%20conf",
+			http.StatusInternalServerError,
+			fmt.Sprintf("{\"message\":\"Internal Server Error\"}\n"),
+			errors.New("just another error"),
+			&fake.RpaasManager{
+				FakeUpdateBlock: func(i, b, c string) error {
+					return errors.New("just another error")
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			path := fmt.Sprintf("/resources/%s/block", instanceName)
+			request := httptest.NewRequest(http.MethodPost, path, strings.NewReader(testCase.requestBody))
+			request.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+			recorder := httptest.NewRecorder()
+			e := configEcho()
+			context := e.NewContext(request, recorder)
+			context.SetParamNames("instance")
+			context.SetParamValues(instanceName)
+			setManager(context, testCase.manager)
+			err := updateBlock(context)
+			assert.Equal(t, testCase.expectedError, err)
+			e.HTTPErrorHandler(err, context)
+			assert.Equal(t, testCase.expectedCode, recorder.Code)
+			assert.Equal(t, testCase.expectedBody, recorder.Body.String())
+		})
+	}
+}

--- a/api/config.go
+++ b/api/config.go
@@ -1,27 +1,13 @@
 package api
 
 import (
-	"time"
-
 	"github.com/tsuru/rpaas-operator/pkg/apis"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
-
-const (
-	apiTimeout   = 10 * time.Second
-	dialTimeout  = 30 * time.Second
-	tcpKeepAlive = 30 * time.Second
-)
-
-type kubeConfig struct {
-	Addr       string
-	CaCert     []byte
-	ClientCert []byte
-	ClientKey  []byte
-}
 
 var cli client.Client
 
@@ -30,15 +16,18 @@ func setup() error {
 	if err != nil {
 		return err
 	}
-	m, err := manager.New(cfg, manager.Options{})
+	scheme := runtime.NewScheme()
+	if err = apis.AddToScheme(scheme); err != nil {
+		return err
+	}
+	m, err := manager.New(cfg, manager.Options{Scheme: scheme})
 	if err != nil {
+		return err
+	}
+	if err = apis.IndexRpaasInstanceName(m); err != nil {
 		return err
 	}
 	cli = m.GetClient()
-	err = apis.AddToScheme(m.GetScheme())
-	if err != nil {
-		return err
-	}
 	go m.Start(signals.SetupSignalHandler())
 	return nil
 }

--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -1,7 +1,9 @@
 package apis
 
 import (
+	"github.com/tsuru/rpaas-operator/pkg/apis/extensions/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToSchemes may be used to add all resources defined in the project to a Scheme
@@ -10,4 +12,14 @@ var AddToSchemes runtime.SchemeBuilder
 // AddToScheme adds all Resources to the Scheme
 func AddToScheme(s *runtime.Scheme) error {
 	return AddToSchemes.AddToScheme(s)
+}
+
+// IndexRpaasInstanceName adds a FieldIndexer for indexing the RpaasInstance's
+// name over the cache, since they can later be consumed via field selector
+// from the client.
+func IndexRpaasInstanceName(m manager.Manager) error {
+	indexerFunc := func(o runtime.Object) []string {
+		return []string{o.(*v1alpha1.RpaasInstance).Name}
+	}
+	return m.GetFieldIndexer().IndexField(&v1alpha1.RpaasInstance{}, "metadata.name", indexerFunc)
 }

--- a/pkg/controller/rpaasinstance/rpaasinstance_controller.go
+++ b/pkg/controller/rpaasinstance/rpaasinstance_controller.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	nginxV1alpha1 "github.com/tsuru/nginx-operator/pkg/apis/nginx/v1alpha1"
+	"github.com/tsuru/rpaas-operator/pkg/apis"
 	"github.com/tsuru/rpaas-operator/pkg/apis/extensions/v1alpha1"
 	extensionsv1alpha1 "github.com/tsuru/rpaas-operator/pkg/apis/extensions/v1alpha1"
 	"github.com/tsuru/rpaas-operator/rpaas/nginx"
@@ -40,6 +41,10 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	if err := apis.IndexRpaasInstanceName(mgr); err != nil {
+		return err
+	}
+
 	// Create a new controller
 	c, err := controller.New("rpaasinstance-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {

--- a/rpaas/fake/manager.go
+++ b/rpaas/fake/manager.go
@@ -12,6 +12,7 @@ type RpaasManager struct {
 	FakeCreateInstance    func(args rpaas.CreateArgs) error
 	FakeDeleteInstance    func(name string) error
 	FakeGetInstance       func(name string) (*v1alpha1.RpaasInstance, error)
+	FakeDeleteBlock       func(instanceName, block string) error
 	FakeUpdateBlock       func(instanceName, block, content string) error
 }
 
@@ -41,6 +42,13 @@ func (m *RpaasManager) GetInstance(name string) (*v1alpha1.RpaasInstance, error)
 		return m.FakeGetInstance(name)
 	}
 	return nil, nil
+}
+
+func (m *RpaasManager) DeleteBlock(instanceName, block string) error {
+	if m.FakeDeleteBlock != nil {
+		return m.FakeDeleteBlock(instanceName, block)
+	}
+	return nil
 }
 
 func (m *RpaasManager) UpdateBlock(instanceName, block, content string) error {

--- a/rpaas/fake/manager.go
+++ b/rpaas/fake/manager.go
@@ -12,6 +12,7 @@ type RpaasManager struct {
 	FakeCreateInstance    func(args rpaas.CreateArgs) error
 	FakeDeleteInstance    func(name string) error
 	FakeGetInstance       func(name string) (*v1alpha1.RpaasInstance, error)
+	FakeUpdateBlock       func(instanceName, block, content string) error
 }
 
 func (m *RpaasManager) UpdateCertificate(instance string, c tls.Certificate) error {
@@ -40,4 +41,11 @@ func (m *RpaasManager) GetInstance(name string) (*v1alpha1.RpaasInstance, error)
 		return m.FakeGetInstance(name)
 	}
 	return nil, nil
+}
+
+func (m *RpaasManager) UpdateBlock(instanceName, block, content string) error {
+	if m.FakeUpdateBlock != nil {
+		return m.FakeUpdateBlock(instanceName, block, content)
+	}
+	return nil
 }

--- a/rpaas/fake/manager.go
+++ b/rpaas/fake/manager.go
@@ -13,6 +13,7 @@ type RpaasManager struct {
 	FakeDeleteInstance    func(name string) error
 	FakeGetInstance       func(name string) (*v1alpha1.RpaasInstance, error)
 	FakeDeleteBlock       func(instanceName, block string) error
+	FakeListBlocks        func(instanceName string) (map[string]string, error)
 	FakeUpdateBlock       func(instanceName, block, content string) error
 }
 
@@ -49,6 +50,13 @@ func (m *RpaasManager) DeleteBlock(instanceName, block string) error {
 		return m.FakeDeleteBlock(instanceName, block)
 	}
 	return nil
+}
+
+func (m *RpaasManager) ListBlocks(instanceName string) (map[string]string, error) {
+	if m.FakeListBlocks != nil {
+		return m.FakeListBlocks(instanceName)
+	}
+	return nil, nil
 }
 
 func (m *RpaasManager) UpdateBlock(instanceName, block, content string) error {

--- a/rpaas/manager.go
+++ b/rpaas/manager.go
@@ -19,7 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -217,11 +216,7 @@ func (m *k8sRpaasManager) UpdateCertificate(instance string, c tls.Certificate) 
 
 func (m *k8sRpaasManager) GetInstance(name string) (*v1alpha1.RpaasInstance, error) {
 	list := &v1alpha1.RpaasInstanceList{}
-	err := m.cli.List(m.ctx, &client.ListOptions{
-		FieldSelector: fields.SelectorFromSet(fields.Set(map[string]string{
-			"namespace.name": name,
-		})),
-	}, list)
+	err := m.cli.List(m.ctx, client.MatchingField("metadata.name", name), list)
 	if err != nil {
 		return nil, err
 	}

--- a/rpaas/manager.go
+++ b/rpaas/manager.go
@@ -25,6 +25,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var (
+	ErrBlockInvalid = ValidationError{Msg: fmt.Sprintf("rpaas: block is not valid (acceptable values are: %v)", getAvailableBlocks())}
+)
+
 type CreateArgs struct {
 	Name        string   `json:"name" form:"name"`
 	Plan        string   `json:"plan" form:"plan"`
@@ -42,6 +46,7 @@ type RpaasManager interface {
 	CreateInstance(args CreateArgs) error
 	DeleteInstance(name string) error
 	GetInstance(name string) (*v1alpha1.RpaasInstance, error)
+	UpdateBlock(instanceName, block, content string) error
 }
 
 type K8SOptions struct {
@@ -121,6 +126,28 @@ func (m *k8sRpaasManager) CreateInstance(args CreateArgs) error {
 		return err
 	}
 	return nil
+}
+
+func (m *k8sRpaasManager) UpdateBlock(instanceName, block, content string) error {
+	instance, err := m.GetInstance(instanceName)
+	if err != nil {
+		return err
+	}
+	if !isBlockValid(block) {
+		return ErrBlockInvalid
+	}
+	if err = m.updateConfigurationBlocks(*instance, block, content); err != nil {
+		return err
+	}
+	if instance.Spec.Blocks == nil {
+		instance.Spec.Blocks = map[v1alpha1.BlockType]v1alpha1.ConfigRef{}
+	}
+	blockType := v1alpha1.BlockType(block)
+	instance.Spec.Blocks[blockType] = v1alpha1.ConfigRef{
+		Name: formatConfigurationBlocksName(*instance),
+		Kind: v1alpha1.ConfigKindConfigMap,
+	}
+	return m.cli.Update(m.ctx, instance)
 }
 
 func (m *k8sRpaasManager) UpdateCertificate(instance string, c tls.Certificate) error {
@@ -209,6 +236,44 @@ func (m *k8sRpaasManager) updateCertificates(ri *v1alpha1.RpaasInstance, certs m
 	return m.cli.Update(m.ctx, ri)
 }
 
+func (m *k8sRpaasManager) createConfigurationBlocks(instance v1alpha1.RpaasInstance, block, content string) error {
+	configBlocks := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      formatConfigurationBlocksName(instance),
+			Namespace: instance.ObjectMeta.Namespace,
+		},
+		Data: map[string]string{
+			block: content,
+		},
+	}
+	return m.cli.Create(m.ctx, configBlocks)
+}
+
+func (m *k8sRpaasManager) getConfigurationBlocks(instance v1alpha1.RpaasInstance) (*corev1.ConfigMap, error) {
+	cm := &corev1.ConfigMap{}
+	namespacedName := types.NamespacedName{
+		Name:      formatConfigurationBlocksName(instance),
+		Namespace: instance.ObjectMeta.Namespace,
+	}
+	err := m.cli.Get(m.ctx, namespacedName, cm)
+	return cm, err
+}
+
+func (m *k8sRpaasManager) updateConfigurationBlocks(instance v1alpha1.RpaasInstance, block, content string) error {
+	configBlocks, err := m.getConfigurationBlocks(instance)
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return m.createConfigurationBlocks(instance, block, content)
+	}
+	if err != nil {
+		return err
+	}
+	if configBlocks.Data == nil {
+		configBlocks.Data = map[string]string{}
+	}
+	configBlocks.Data[block] = content
+	return m.cli.Update(m.ctx, configBlocks)
+}
+
 func convertTLSCertificate(c *tls.Certificate) ([]byte, []byte, error) {
 	certificatePem, err := convertCertificateToPem(c.Certificate)
 	if err != nil {
@@ -252,6 +317,10 @@ func convertPrivateKeyToPem(key crypto.PrivateKey) ([]byte, error) {
 
 func formatCertificateSecretName(ri v1alpha1.RpaasInstance, name string) string {
 	return fmt.Sprintf("%s-certificate-%s", ri.ObjectMeta.Name, name)
+}
+
+func formatConfigurationBlocksName(instance v1alpha1.RpaasInstance) string {
+	return fmt.Sprintf("%s-blocks", instance.ObjectMeta.Name)
 }
 
 func newCertificateSecret(ri v1alpha1.RpaasInstance, name string, rawCertPem, rawKeyPem []byte) *corev1.Secret {
@@ -331,4 +400,21 @@ func parseTagArg(tags []string, name string, destination *string) {
 func parseTags(args CreateArgs) {
 	parseTagArg(args.Tags, "flavor", &args.Flavor)
 	parseTagArg(args.Tags, "ip", &args.IP)
+}
+
+func getAvailableBlocks() []v1alpha1.BlockType {
+	return []v1alpha1.BlockType{
+		v1alpha1.BlockTypeRoot,
+		v1alpha1.BlockTypeHTTP,
+		v1alpha1.BlockTypeServer,
+	}
+}
+
+func isBlockValid(block string) bool {
+	for _, b := range getAvailableBlocks() {
+		if v1alpha1.BlockType(block) == b {
+			return true
+		}
+	}
+	return false
 }

--- a/rpaas/manager.go
+++ b/rpaas/manager.go
@@ -26,7 +26,8 @@ import (
 )
 
 var (
-	ErrBlockInvalid = ValidationError{Msg: fmt.Sprintf("rpaas: block is not valid (acceptable values are: %v)", getAvailableBlocks())}
+	ErrBlockInvalid      = ValidationError{Msg: fmt.Sprintf("rpaas: block is not valid (acceptable values are: %v)", getAvailableBlocks())}
+	ErrBlockIsNotDefined = ValidationError{Msg: "rpaas: block is not defined"}
 )
 
 type CreateArgs struct {
@@ -46,6 +47,7 @@ type RpaasManager interface {
 	CreateInstance(args CreateArgs) error
 	DeleteInstance(name string) error
 	GetInstance(name string) (*v1alpha1.RpaasInstance, error)
+	DeleteBlock(instanceName, block string) error
 	UpdateBlock(instanceName, block, content string) error
 }
 
@@ -126,6 +128,28 @@ func (m *k8sRpaasManager) CreateInstance(args CreateArgs) error {
 		return err
 	}
 	return nil
+}
+
+func (m *k8sRpaasManager) DeleteBlock(instanceName, block string) error {
+	instance, err := m.GetInstance(instanceName)
+	if err != nil {
+		return err
+	}
+	if !isBlockValid(block) {
+		return ErrBlockInvalid
+	}
+	if err = m.deleteConfigurationBlocks(*instance, block); err != nil {
+		return err
+	}
+	if instance.Spec.Blocks == nil {
+		return ErrBlockIsNotDefined
+	}
+	blockType := v1alpha1.BlockType(block)
+	if _, ok := instance.Spec.Blocks[blockType]; !ok {
+		return ErrBlockIsNotDefined
+	}
+	delete(instance.Spec.Blocks, blockType)
+	return m.cli.Update(m.ctx, instance)
 }
 
 func (m *k8sRpaasManager) UpdateBlock(instanceName, block, content string) error {
@@ -271,6 +295,24 @@ func (m *k8sRpaasManager) updateConfigurationBlocks(instance v1alpha1.RpaasInsta
 		configBlocks.Data = map[string]string{}
 	}
 	configBlocks.Data[block] = content
+	return m.cli.Update(m.ctx, configBlocks)
+}
+
+func (m *k8sRpaasManager) deleteConfigurationBlocks(instance v1alpha1.RpaasInstance, block string) error {
+	configBlocks, err := m.getConfigurationBlocks(instance)
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return ErrBlockIsNotDefined
+	}
+	if err != nil {
+		return err
+	}
+	if configBlocks.Data == nil {
+		return ErrBlockIsNotDefined
+	}
+	if _, ok := configBlocks.Data[block]; !ok {
+		return ErrBlockIsNotDefined
+	}
+	delete(configBlocks.Data, block)
 	return m.cli.Update(m.ctx, configBlocks)
 }
 

--- a/rpaas/manager.go
+++ b/rpaas/manager.go
@@ -48,6 +48,7 @@ type RpaasManager interface {
 	DeleteInstance(name string) error
 	GetInstance(name string) (*v1alpha1.RpaasInstance, error)
 	DeleteBlock(instanceName, block string) error
+	ListBlocks(instanceName string) (map[string]string, error)
 	UpdateBlock(instanceName, block, content string) error
 }
 
@@ -150,6 +151,24 @@ func (m *k8sRpaasManager) DeleteBlock(instanceName, block string) error {
 	}
 	delete(instance.Spec.Blocks, blockType)
 	return m.cli.Update(m.ctx, instance)
+}
+
+func (m *k8sRpaasManager) ListBlocks(instanceName string) (map[string]string, error) {
+	instance, err := m.GetInstance(instanceName)
+	if err != nil {
+		return nil, err
+	}
+	configBlocks, err := m.getConfigurationBlocks(*instance)
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return map[string]string{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if configBlocks.Data == nil {
+		return map[string]string{}, nil
+	}
+	return configBlocks.Data, nil
 }
 
 func (m *k8sRpaasManager) UpdateBlock(instanceName, block, content string) error {


### PR DESCRIPTION
This PR adds a custom field indexer for indexing all RpaasInstances CRs by name over the cache. It makes possible the filtering using a field selector from RPaas API and rpaasinstance controller.