### PR TITLE
Limit the number of ConfigMaps

### DIFF
--- a/pkg/apis/extensions/v1alpha1/rpaasinstance_types.go
+++ b/pkg/apis/extensions/v1alpha1/rpaasinstance_types.go
@@ -45,9 +45,9 @@ type RpaasInstanceSpec struct {
 	// +optional
 	ExtraFiles *nginxv1alpha1.FilesRef `json:"extraFiles,omitempty"`
 
-	// The number of old ReplicaSets to retain to allow rollback.
+	// The number of old Configs to retain to allow rollback.
 	// +optional
-	ConfigHistoryLimit *int32 `json:"ConfigHistoryLimit,omitempty"`
+	ConfigHistoryLimit *int `json:"configHistoryLimit,omitempty"`
 }
 
 // RpaasInstanceStatus defines the observed state of RpaasInstance

--- a/pkg/apis/extensions/v1alpha1/rpaasinstance_types.go
+++ b/pkg/apis/extensions/v1alpha1/rpaasinstance_types.go
@@ -44,6 +44,10 @@ type RpaasInstanceSpec struct {
 	// ExtraFiles points to a ConfigMap where the files are stored.
 	// +optional
 	ExtraFiles *nginxv1alpha1.FilesRef `json:"extraFiles,omitempty"`
+
+	// The number of old ReplicaSets to retain to allow rollback.
+	// +optional
+	ConfigHistoryLimit *int32 `json:"ConfigHistoryLimit,omitempty"`
 }
 
 // RpaasInstanceStatus defines the observed state of RpaasInstance

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -163,7 +163,7 @@ func (in *RpaasInstanceSpec) DeepCopyInto(out *RpaasInstanceSpec) {
 	}
 	if in.ConfigHistoryLimit != nil {
 		in, out := &in.ConfigHistoryLimit, &out.ConfigHistoryLimit
-		*out = new(int32)
+		*out = new(int)
 		**out = **in
 	}
 	return

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -161,6 +161,11 @@ func (in *RpaasInstanceSpec) DeepCopyInto(out *RpaasInstanceSpec) {
 		*out = new(nginxv1alpha1.FilesRef)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ConfigHistoryLimit != nil {
+		in, out := &in.ConfigHistoryLimit, &out.ConfigHistoryLimit
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/rpaasinstance/rpaasinstance_controller.go
+++ b/pkg/controller/rpaasinstance/rpaasinstance_controller.go
@@ -274,6 +274,7 @@ func (r *ReconcileRpaasInstance) listConfigs(instance *v1alpha1.RpaasInstance) (
 
 	if err := listOptions.SetLabelSelector(labelSelector); err != nil {
 		logrus.Errorf("Failed to query nginx configs: %v", err)
+		return nil, err
 	}
 
 	err := r.client.List(context.TODO(), listOptions, configList)

--- a/pkg/controller/rpaasinstance/rpaasinstance_controller.go
+++ b/pkg/controller/rpaasinstance/rpaasinstance_controller.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	defaultConfigHistoryLimit = 3
+	defaultConfigHistoryLimit = 10
 )
 
 var log = logf.Log.WithName("controller_rpaasinstance")
@@ -363,5 +363,5 @@ func shouldDeleteOldConfig(instance *v1alpha1.RpaasInstance, configList *corev1.
 	}
 
 	listSize := len(configList.Items)
-	return listSize > limit
+	return listSize >= limit
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -313,7 +313,7 @@ func Test_RpaasApi(t *testing.T) {
 		}, rpaasInstance.Spec.Locations)
 	})
 
-	t.Run("limits the number of configs to 3 by default", func(t *testing.T) {
+	t.Run("limits the number of configs to 10 by default", func(t *testing.T) {
 		instanceName := "my-instance"
 		teamName := "team-one"
 		planName := "basic"
@@ -328,19 +328,15 @@ func Test_RpaasApi(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, len(configList.Items), 1)
 
-		cleanBlockFunc, err := api.createBlock(instanceName, teamName, blockName, "content=location=/test1{return 204;}")
-		require.NoError(t, err)
-		defer cleanBlockFunc()
-		cleanBlockFunc, err = api.createBlock(instanceName, teamName, blockName, "content=location=/test2{return 204;}")
-		require.NoError(t, err)
-		defer cleanBlockFunc()
-		cleanBlockFunc, err = api.createBlock(instanceName, teamName, blockName, "content=location=/test3{return 204;}")
-		require.NoError(t, err)
-		defer cleanBlockFunc()
+		for i := 0; i < 11; i++ {
+			cleanBlockFunc, err := api.createBlock(instanceName, teamName, blockName, fmt.Sprintf("content=location=/test%d{return 204;}", i))
+			require.NoError(t, err)
+			defer cleanBlockFunc()
+		}
 
 		configList, err = getConfigList(instanceName, namespaceName)
 		require.NoError(t, err)
-		assert.Equal(t, len(configList.Items), 3)
+		assert.Equal(t, 10, len(configList.Items))
 	})
 }
 

--- a/test/testdata/rpaas-full.yaml
+++ b/test/testdata/rpaas-full.yaml
@@ -43,6 +43,7 @@ metadata:
   name: my-instance
 spec:
   replicas: 2
+  configHistoryLimit: 2
   planName: basic
   blocks:
     root:


### PR DESCRIPTION
Every time the user adds a new config, a `ConfigMap` is generated. This PR limits the number of `ConfigMap` an instance can have. 

The default number of `ConfigMaps` is 10, but this value can be configured through the field `RpaasInstance.Spec.ConfigHistoryLimit`. When the max number is reached, the oldest `ConfigMaps` is deleted.
