### PR TITLE
Add VTS to config template

### DIFF
--- a/rpaas/nginx/configuration_render.go
+++ b/rpaas/nginx/configuration_render.go
@@ -196,7 +196,7 @@ http {
 {{if .Config.VTSEnabled}}
 			location /status {
 				vhost_traffic_status_display;
-        vhost_traffic_status_display_format prometheus;
+				vhost_traffic_status_display_format prometheus;
 			}
 {{end}}
 

--- a/rpaas/nginx/configuration_render.go
+++ b/rpaas/nginx/configuration_render.go
@@ -190,6 +190,18 @@ http {
 
     {{template "http" .}}
 
+		server {
+			listen 8800;
+
+{{if .Config.VTSEnabled}}
+			location /status {
+				vhost_traffic_status_display;
+        vhost_traffic_status_display_format prometheus;
+			}
+{{end}}
+
+		}
+
     server {
         listen 8080 default_server{{with .Config.HTTPListenOptions}} {{.}}{{end}};
 

--- a/rpaas/nginx/configuration_render_test.go
+++ b/rpaas/nginx/configuration_render_test.go
@@ -36,6 +36,17 @@ func TestRpaasConfigurationRenderer_Render(t *testing.T) {
 		{
 			renderer: NewRpaasConfigurationRenderer(ConfigurationBlocks{}),
 			data: ConfigurationData{
+				Config:   &v1alpha1.NginxConfig{},
+				Instance: &v1alpha1.RpaasInstanceSpec{},
+			},
+			assertion: func(t *testing.T, result string, err error) {
+				require.NoError(t, err)
+				assert.Regexp(t, `listen 8800;`, result)
+			},
+		},
+		{
+			renderer: NewRpaasConfigurationRenderer(ConfigurationBlocks{}),
+			data: ConfigurationData{
 				Config: &v1alpha1.NginxConfig{
 					RequestIDEnabled: true,
 				},
@@ -114,6 +125,10 @@ func TestRpaasConfigurationRenderer_Render(t *testing.T) {
 			assertion: func(t *testing.T, result string, err error) {
 				require.NoError(t, err)
 				assert.Regexp(t, `vhost_traffic_status_zone;`, result)
+				assert.Regexp(t, `\s+location /status {
+\s+vhost_traffic_status_display;
+\s+vhost_traffic_status_display_format prometheus;
+`, result)
 			},
 		},
 		{


### PR DESCRIPTION
- Adds administrative server listening on port 8800
- Adds /status route to config when VTS is enabled on plan
