### PR TITLE
nginx: check if cache purge returns 200 instead of 204

### DIFF
--- a/rpaas/nginx/manager.go
+++ b/rpaas/nginx/manager.go
@@ -78,7 +78,7 @@ func (m NginxManager) purgeRequest(host, path string, headers map[string]string)
 		logrus.Error(errorMessage)
 		return NginxError{Msg: errorMessage}
 	}
-	if resp.StatusCode != http.StatusNoContent {
+	if resp.StatusCode != http.StatusOK {
 		errorMessage := fmt.Sprintf("cannot purge nginx cache - unexpected response from nginx server: %v", resp)
 		logrus.Error(errorMessage)
 		return NginxError{Msg: errorMessage}

--- a/rpaas/nginx/manager_test.go
+++ b/rpaas/nginx/manager_test.go
@@ -49,7 +49,7 @@ func TestNginxManager_PurgeCache(t *testing.T) {
 			},
 			nginxResponse: func(w http.ResponseWriter, r *http.Request) {
 				if r.RequestURI == "/purge/some/path/index.html" {
-					w.WriteHeader(http.StatusNoContent)
+					w.WriteHeader(http.StatusOK)
 				} else {
 					w.WriteHeader(http.StatusNotFound)
 				}
@@ -64,7 +64,7 @@ func TestNginxManager_PurgeCache(t *testing.T) {
 			},
 			nginxResponse: func(w http.ResponseWriter, r *http.Request) {
 				if r.RequestURI == "/purge/http/index.html" || r.RequestURI == "/purge/https/index.html" {
-					w.WriteHeader(http.StatusNoContent)
+					w.WriteHeader(http.StatusOK)
 				} else {
 					w.WriteHeader(http.StatusNotFound)
 				}
@@ -79,7 +79,7 @@ func TestNginxManager_PurgeCache(t *testing.T) {
 			},
 			nginxResponse: func(w http.ResponseWriter, r *http.Request) {
 				if r.Header.Get("Accept-Encoding") == "gzip" || r.Header.Get("Accept-Encoding") == "identity" {
-					w.WriteHeader(http.StatusNoContent)
+					w.WriteHeader(http.StatusOK)
 				} else {
 					w.WriteHeader(http.StatusNotAcceptable)
 				}
@@ -94,7 +94,7 @@ func TestNginxManager_PurgeCache(t *testing.T) {
 			},
 			nginxResponse: func(w http.ResponseWriter, r *http.Request) {
 				if r.Header.Get("Accept-Encoding") == "gzip" || r.Header.Get("Accept-Encoding") == "identity" {
-					w.WriteHeader(http.StatusNoContent)
+					w.WriteHeader(http.StatusOK)
 				} else {
 					w.WriteHeader(http.StatusNotAcceptable)
 				}


### PR DESCRIPTION
Nginx returns 200 and not 204 when the cache is successfully purged. This fixes a bug where the 
`/purge` route on API always tells the user that 0 objects were purged, no matter if the cache was purged on several servers.