### PR TITLE
Add support to default flavors

### DIFF
--- a/internal/pkg/rpaas/k8s.go
+++ b/internal/pkg/rpaas/k8s.go
@@ -379,6 +379,9 @@ func (m *k8sRpaasManager) GetFlavors(ctx context.Context) ([]Flavor, error) {
 
 	var result []Flavor
 	for _, flavor := range flavors {
+		if flavor.Spec.Default {
+			continue
+		}
 		result = append(result, Flavor{
 			Name:        flavor.Name,
 			Description: flavor.Spec.Description,

--- a/internal/pkg/rpaas/k8s_test.go
+++ b/internal/pkg/rpaas/k8s_test.go
@@ -2868,6 +2868,16 @@ func Test_k8sRpaasManager_GetFlavors(t *testing.T) {
 						Description: "Just a human readable description to mango flavor",
 					},
 				},
+				&v1alpha1.RpaasFlavor{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default",
+						Namespace: namespaceName(),
+					},
+					Spec: v1alpha1.RpaasFlavorSpec{
+						Default:     true,
+						Description: "Default flavor that should not appear on flavors list",
+					},
+				},
 			},
 			expected: []Flavor{
 				{
@@ -2890,7 +2900,7 @@ func Test_k8sRpaasManager_GetFlavors(t *testing.T) {
 
 			flavors, err := manager.GetFlavors(context.TODO())
 			require.NoError(t, err)
-			assert.Equal(t, flavors, tt.expected)
+			assert.Equal(t, tt.expected, flavors)
 		})
 	}
 }

--- a/pkg/apis/extensions/v1alpha1/rpaasflavor_types.go
+++ b/pkg/apis/extensions/v1alpha1/rpaasflavor_types.go
@@ -19,6 +19,11 @@ type RpaasFlavorSpec struct {
 	// associated RpaasInstance.
 	// +optional
 	InstanceTemplate *RpaasInstanceSpec `json:"instanceTemplate,omitempty"`
+
+	// Default defines if the flavor should be applied by default on
+	// every service instance. Default flavors cannot be listed on RpaasFlavorList.
+	// +optional
+	Default bool `json:"default,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/rpaasinstance/rpaasinstance_controller.go
+++ b/pkg/controller/rpaasinstance/rpaasinstance_controller.go
@@ -200,6 +200,10 @@ func (r *ReconcileRpaasInstance) mergeInstanceWithFlavors(ctx context.Context, i
 			return nil, err
 		}
 
+		if flavor.Spec.Default {
+			continue
+		}
+
 		if err := mergeInstanceWithFlavor(instance, flavor); err != nil {
 			return nil, err
 		}
@@ -210,7 +214,7 @@ func (r *ReconcileRpaasInstance) mergeInstanceWithFlavors(ctx context.Context, i
 }
 
 func mergeInstanceWithFlavor(instance *v1alpha1.RpaasInstance, flavor v1alpha1.RpaasFlavor) error {
-	logger := log.WithName("mergeInstanceWithFlavors").
+	logger := log.WithName("mergeInstanceWithFlavor").
 		WithValues("RpaasInstance", types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace})
 	if flavor.Spec.InstanceTemplate != nil {
 		mergedInstanceSpec, err := mergeInstance(*flavor.Spec.InstanceTemplate, instance.Spec)


### PR DESCRIPTION
Default flavors should be merged on the instance, no matter if they are listed or not. With this, we can set different instance templates for each namespace.  They should not be visible to a user listing the available flavors.