### PR TITLE
feat: add vts histogram support

### DIFF
--- a/internal/pkg/rpaas/nginx/configuration_render.go
+++ b/internal/pkg/rpaas/nginx/configuration_render.go
@@ -191,6 +191,9 @@ http {
 
 {{if .Config.VTSEnabled}}
     vhost_traffic_status_zone;
+    {{if .Config.VTSStatusHistogramBuckets}}
+    vhost_traffic_status_histogram_buckets {{.Config.VTSStatusHistogramBuckets}};
+    {{end}}
 {{end}}
 
 {{if $instance.Spec.Host}}

--- a/internal/pkg/rpaas/nginx/configuration_render_test.go
+++ b/internal/pkg/rpaas/nginx/configuration_render_test.go
@@ -154,6 +154,25 @@ func TestRpaasConfigurationRenderer_Render(t *testing.T) {
 		{
 			renderer: NewRpaasConfigurationRenderer(ConfigurationBlocks{}),
 			data: ConfigurationData{
+				Config: &v1alpha1.NginxConfig{
+					VTSEnabled:                v1alpha1.Bool(true),
+					VTSStatusHistogramBuckets: "0.001 0.005 0.01 0.025 0.05 0.1 0.25 0.5 1 2.5 5 10",
+				},
+				Instance: &v1alpha1.RpaasInstance{},
+			},
+			assertion: func(t *testing.T, result string, err error) {
+				require.NoError(t, err)
+				assert.Regexp(t, `vhost_traffic_status_zone;`, result)
+				assert.Regexp(t, `vhost_traffic_status_histogram_buckets 0.001 0.005 0.01 0.025 0.05 0.1 0.25 0.5 1 2.5 5 10;`, result)
+				assert.Regexp(t, `\s+location /status {
+\s+vhost_traffic_status_display;
+\s+vhost_traffic_status_display_format prometheus;
+`, result)
+			},
+		},
+		{
+			renderer: NewRpaasConfigurationRenderer(ConfigurationBlocks{}),
+			data: ConfigurationData{
 				Config: &v1alpha1.NginxConfig{},
 				Instance: &v1alpha1.RpaasInstance{
 					Spec: v1alpha1.RpaasInstanceSpec{

--- a/pkg/apis/extensions/v1alpha1/rpaasplan_types.go
+++ b/pkg/apis/extensions/v1alpha1/rpaasplan_types.go
@@ -71,7 +71,8 @@ type NginxConfig struct {
 	HTTPListenOptions  string `json:"httpListenOptions,omitempty"`
 	HTTPSListenOptions string `json:"httpsListenOptions,omitempty"`
 
-	VTSEnabled *bool `json:"vtsEnabled,omitempty"`
+	VTSEnabled                *bool  `json:"vtsEnabled,omitempty"`
+	VTSStatusHistogramBuckets string `json:"vtsStatusHistogramBuckets,omitempty"`
 
 	SyslogEnabled       *bool  `json:"syslogEnabled,omitempty"`
 	SyslogServerAddress string `json:"syslogServerAddress,omitempty"`


### PR DESCRIPTION
RPaaS Operator is not exposing status histogram metrics which are essential for monitoring latency.

TBD:
- [ ]  Set default buckets for all RPaaS