### PR TITLE
feat(rpaas/api): receive flavors, IP and plan template as plan parameter

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -7,13 +7,16 @@ package api
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
+	"github.com/ajg/form"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/tsuru/rpaas-operator/config"
@@ -158,7 +161,7 @@ func errorMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 
 func newEcho() *echo.Echo {
 	e := echo.New()
-
+	e.Binder = new(requestBinder)
 	e.HideBanner = true
 
 	e.Use(middleware.Recover())
@@ -220,4 +223,30 @@ func newEcho() *echo.Echo {
 	e.POST("/resources/:instance/purge", cachePurge)
 
 	return e
+}
+
+type requestBinder struct{}
+
+func (b *requestBinder) Bind(i interface{}, c echo.Context) error {
+	req := c.Request()
+
+	ctype := req.Header.Get(echo.HeaderContentType)
+	if !strings.HasPrefix(ctype, echo.MIMEApplicationForm) {
+		c.Response().Header().Set("Accept", echo.MIMEApplicationForm)
+		return echo.ErrUnsupportedMediaType
+	}
+
+	if err := newDecoder(req.Body).Decode(i); err != nil {
+		return fmt.Errorf("cannot decode the parameters: %w", err)
+	}
+	defer req.Body.Close()
+
+	return nil
+}
+
+func newDecoder(r io.Reader) *form.Decoder {
+	decoder := form.NewDecoder(r)
+	decoder.IgnoreCase(true)
+	decoder.IgnoreUnknownKeys(true)
+	return decoder
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,96 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestBinder_Bind(t *testing.T) {
+	type t1 struct {
+		Name    string                 `form:"name"`
+		Tags    []string               `form:"tags"`
+		Complex map[string]interface{} `form:"complex"`
+		Ignored bool                   `form:"-"`
+	}
+
+	tests := []struct {
+		name   string
+		c      echo.Context
+		data   interface{}
+		assert func(*testing.T, error, interface{}, echo.Context)
+	}{
+		{
+			name: "when content-type is not application/x-www-form-urleconded",
+			c: func() echo.Context {
+				body := `{"name": "my-instance"}`
+				e := newEcho()
+				req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+				req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+				return e.NewContext(req, httptest.NewRecorder())
+			}(),
+			assert: func(t *testing.T, err error, d interface{}, c echo.Context) {
+				require.Error(t, err)
+				assert.EqualError(t, err, "code=415, message=Unsupported Media Type, internal=<nil>")
+				assert.Equal(t, "application/x-www-form-urlencoded", c.Response().Header().Get("Accept"))
+			},
+		},
+		{
+			name: "submitting a complex object",
+			c: func() echo.Context {
+				body := `name=my-instance&tags.0=tag1&tags.1=tag2&tags.2=tag3&ignored=true&complex.key1=1&complex.other.key=value`
+				e := newEcho()
+				req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+				req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+				return e.NewContext(req, httptest.NewRecorder())
+			}(),
+			data: &t1{},
+			assert: func(t *testing.T, err error, d interface{}, c echo.Context) {
+				require.NoError(t, err)
+				assert.Equal(t, &t1{
+					Name: "my-instance",
+					Tags: []string{"tag1", "tag2", "tag3"},
+					Complex: map[string]interface{}{
+						"key1": "1",
+						"other": map[string]interface{}{
+							"key": "value",
+						},
+					},
+				}, d)
+			},
+		},
+		{
+			name: "when some error occurs on decode method",
+			c: func() echo.Context {
+				body := `name=my-instance&tags.0=tag1&tags.1=tag2&tags.2=tag3&ignored=true&complex.key1=1&complex.other.key=value`
+				e := newEcho()
+				req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+				req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+				return e.NewContext(req, httptest.NewRecorder())
+			}(),
+			data: func() string { return "cannot decode a function" },
+			assert: func(t *testing.T, err error, d interface{}, c echo.Context) {
+				require.Error(t, err)
+				assert.EqualError(t, err, "cannot decode the parameters: func() string has unsupported kind func")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotNil(t, tt.assert)
+			b := &requestBinder{}
+			err := b.Bind(tt.data, tt.c)
+			tt.assert(t, err, tt.data, tt.c)
+		})
+	}
+}

--- a/api/service_handlers.go
+++ b/api/service_handlers.go
@@ -72,12 +72,6 @@ func serviceUpdate(c echo.Context) error {
 	return c.NoContent(http.StatusOK)
 }
 
-type plan struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Default     bool   `json:"default"`
-}
-
 func servicePlans(c echo.Context) error {
 	manager, err := getManager(c)
 	if err != nil {
@@ -89,20 +83,11 @@ func servicePlans(c echo.Context) error {
 		return err
 	}
 
-	var result []plan
-	for _, p := range plans {
-		result = append(result, plan{
-			Name:        p.Name,
-			Description: p.Spec.Description,
-			Default:     p.Spec.Default,
-		})
+	if plans == nil {
+		plans = make([]rpaas.Plan, 0)
 	}
 
-	if result == nil {
-		result = []plan{}
-	}
-
-	return c.JSON(http.StatusOK, result)
+	return c.JSON(http.StatusOK, plans)
 }
 
 func serviceInfo(c echo.Context) error {

--- a/api/service_handlers_test.go
+++ b/api/service_handlers_test.go
@@ -32,6 +32,7 @@ func Test_serviceCreate(t *testing.T) {
 	}{
 		{
 			name:         "when some error is returned",
+			requestBody:  "foo=bar",
 			expectedCode: http.StatusBadRequest,
 			expectedBody: "some error message",
 			manager: &fake.RpaasManager{
@@ -137,6 +138,7 @@ func Test_serviceUpdate(t *testing.T) {
 		{
 			name:         "when some error is returned",
 			instance:     "my-instance",
+			requestBody:  "foo=bar",
 			expectedCode: http.StatusBadRequest,
 			expectedBody: "some error",
 			manager: &fake.RpaasManager{

--- a/api/service_handlers_test.go
+++ b/api/service_handlers_test.go
@@ -222,7 +222,7 @@ func Test_servicePlans(t *testing.T) {
 		name          string
 		expectedCode  int
 		expectedError string
-		expectedPlans []plan
+		expectedPlans []rpaas.Plan
 		manager       rpaas.RpaasManager
 	}{
 		{
@@ -230,7 +230,7 @@ func Test_servicePlans(t *testing.T) {
 			expectedCode:  http.StatusConflict,
 			expectedError: "some error",
 			manager: &fake.RpaasManager{
-				FakeGetPlans: func() ([]v1alpha1.RpaasPlan, error) {
+				FakeGetPlans: func() ([]rpaas.Plan, error) {
 					return nil, rpaas.ConflictError{Msg: "some error"}
 				},
 			},
@@ -238,9 +238,9 @@ func Test_servicePlans(t *testing.T) {
 		{
 			name:          "when has no plans",
 			expectedCode:  http.StatusOK,
-			expectedPlans: []plan{},
+			expectedPlans: []rpaas.Plan{},
 			manager: &fake.RpaasManager{
-				FakeGetPlans: func() ([]v1alpha1.RpaasPlan, error) {
+				FakeGetPlans: func() ([]rpaas.Plan, error) {
 					return nil, nil
 				},
 			},
@@ -248,32 +248,24 @@ func Test_servicePlans(t *testing.T) {
 		{
 			name:         "when returns several plans",
 			expectedCode: http.StatusOK,
-			expectedPlans: []plan{
+			expectedPlans: []rpaas.Plan{
 				{
 					Name: "my-plan",
 				},
 				{
 					Name:        "my-default-plan",
 					Description: "Some description about my-default-plan.",
-					Default:     true,
 				},
 			},
 			manager: &fake.RpaasManager{
-				FakeGetPlans: func() ([]v1alpha1.RpaasPlan, error) {
-					return []v1alpha1.RpaasPlan{
+				FakeGetPlans: func() ([]rpaas.Plan, error) {
+					return []rpaas.Plan{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "my-plan",
-							},
+							Name: "my-plan",
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "my-default-plan",
-							},
-							Spec: v1alpha1.RpaasPlanSpec{
-								Description: "Some description about my-default-plan.",
-								Default:     true,
-							},
+							Name:        "my-default-plan",
+							Description: "Some description about my-default-plan.",
 						},
 					}, nil
 				},
@@ -295,9 +287,9 @@ func Test_servicePlans(t *testing.T) {
 				assert.Regexp(t, tt.expectedError, bodyContent(rsp))
 				return
 			}
-			var result []plan
+			var result []rpaas.Plan
 			require.NoError(t, json.Unmarshal([]byte(bodyContent(rsp)), &result))
-			assert.Equal(t, result, tt.expectedPlans)
+			assert.Equal(t, tt.expectedPlans, result)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/operator-framework/operator-sdk v0.13.0
 	github.com/pkg/errors v0.8.1
+	github.com/pmorie/go-open-service-broker-client v0.0.0-20190909175253-906fa5f9c249
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tsuru/rpaas-operator
 go 1.13
 
 require (
+	github.com/ajg/form v1.5.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/go-openapi/spec v0.19.2

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/Rican7/retry v0.1.0/go.mod h1:FgOROf8P5bebcC1DS0PdOQiqGUridaZvikzUmkF
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20170410192909-ea383cf3ba6e/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
+github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/ant31/crd-validation v0.0.0-20180702145049-30f8a35d0ac2/go.mod h1:X0noFIik9YqfhGYBLEHg8LJKEwy7QIitLQuFMpKLcPk=

--- a/go.sum
+++ b/go.sum
@@ -509,6 +509,8 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmorie/go-open-service-broker-client v0.0.0-20190909175253-906fa5f9c249 h1:LzBGqIqO5Mhzjg1HaXTUOYWSCLZToEeY6rCks4ehX1s=
+github.com/pmorie/go-open-service-broker-client v0.0.0-20190909175253-906fa5f9c249/go.mod h1:6d5FSWVMC68G2RoLKixGVhkoNlgoEC/phmruM0yHdjQ=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/pquerna/ffjson v0.0.0-20180717144149-af8b230fcd20/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/internal/pkg/rpaas/fake/manager.go
+++ b/internal/pkg/rpaas/fake/manager.go
@@ -30,7 +30,7 @@ type RpaasManager struct {
 	FakeInstanceAddress   func(name string) (string, error)
 	FakeInstanceStatus    func(name string) (*nginxv1alpha1.Nginx, rpaas.PodStatusMap, error)
 	FakeScale             func(instanceName string, replicas int32) error
-	FakeGetPlans          func() ([]v1alpha1.RpaasPlan, error)
+	FakeGetPlans          func() ([]rpaas.Plan, error)
 	FakeGetFlavors        func() ([]rpaas.Flavor, error)
 	FakeCreateExtraFiles  func(instanceName string, files ...rpaas.File) error
 	FakeDeleteExtraFiles  func(instanceName string, filenames ...string) error
@@ -148,7 +148,7 @@ func (m *RpaasManager) Scale(ctx context.Context, instanceName string, replicas 
 	return nil
 }
 
-func (m *RpaasManager) GetPlans(ctx context.Context) ([]v1alpha1.RpaasPlan, error) {
+func (m *RpaasManager) GetPlans(ctx context.Context) ([]rpaas.Plan, error) {
 	if m.FakeGetPlans != nil {
 		return m.FakeGetPlans()
 	}

--- a/internal/pkg/rpaas/k8s.go
+++ b/internal/pkg/rpaas/k8s.go
@@ -1515,10 +1515,6 @@ func (m *k8sRpaasManager) GetInstanceInfo(ctx context.Context, instanceName stri
 }
 
 func buildServiceInstanceParametersForPlan(flavors []Flavor) interface{} {
-	if len(flavors) == 0 {
-		return nil
-	}
-
 	return map[string]interface{}{
 		"$id":     "https://example.com/schema.json",
 		"$schema": "https://json-schema.org/draft-07/schema#",
@@ -1531,6 +1527,14 @@ func buildServiceInstanceParametersForPlan(flavors []Flavor) interface{} {
 				},
 				"description": formatFlavorsDescription(flavors),
 				"enum":        flavorNames(flavors),
+			},
+			"ip": map[string]interface{}{
+				"type":        "string",
+				"description": "IP address that will be assigned to load balancer.\nExamples:\n\tip=192.168.15.10",
+			},
+			"plan-override": map[string]interface{}{
+				"type":        "object",
+				"description": "Allows an instance to change its plan parameters to specific ones.\nExamples:\n\tplan-override={\"config\": {\"cacheEnabled\": false}}\n\tplan-override={\"image\": \"tsuru/nginx:latest\"}",
 			},
 		},
 		"definitions": map[string]interface{}{

--- a/internal/pkg/rpaas/k8s_test.go
+++ b/internal/pkg/rpaas/k8s_test.go
@@ -2812,8 +2812,13 @@ func Test_k8sRpaasManager_CreateInstance(t *testing.T) {
 		},
 		{
 			name:          "invalid flavor",
-			args:          CreateArgs{Name: "r1", Team: "t1", Tags: []string{"flavor=aaaaa"}},
+			args:          CreateArgs{Name: "r1", Team: "t1", Parameters: map[string]interface{}{"flavors": map[string]interface{}{"0": "aaaaa"}}},
 			expectedError: `flavor "aaaaa" not found`,
+		},
+		{
+			name:          "duplicated flavor",
+			args:          CreateArgs{Name: "r1", Team: "t1", Parameters: map[string]interface{}{"flavors": map[string]interface{}{"0": "strawberry", "1": "strawberry"}}},
+			expectedError: `flavor "strawberry" only can be set once`,
 		},
 		{
 			name:          "instance already exists",
@@ -2927,7 +2932,7 @@ func Test_k8sRpaasManager_CreateInstance(t *testing.T) {
 		},
 		{
 			name: "with flavor",
-			args: CreateArgs{Name: "r1", Team: "t1", Tags: []string{"flavor=strawberry"}},
+			args: CreateArgs{Name: "r1", Team: "t1", Parameters: map[string]interface{}{"flavors": map[string]interface{}{"0": "strawberry"}}},
 			expected: v1alpha1.RpaasInstance{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "RpaasInstance",
@@ -2938,8 +2943,8 @@ func Test_k8sRpaasManager_CreateInstance(t *testing.T) {
 					Namespace:       "rpaasv2",
 					ResourceVersion: "1",
 					Annotations: map[string]string{
+						"rpaas.extensions.tsuru.io/tags":        "",
 						"rpaas.extensions.tsuru.io/description": "",
-						"rpaas.extensions.tsuru.io/tags":        "flavor=strawberry",
 						"rpaas.extensions.tsuru.io/team-owner":  "t1",
 					},
 					Labels: map[string]string{

--- a/internal/pkg/rpaas/manager.go
+++ b/internal/pkg/rpaas/manager.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
 	nginxv1alpha1 "github.com/tsuru/nginx-operator/pkg/apis/nginx/v1alpha1"
 	"github.com/tsuru/rpaas-operator/pkg/apis/extensions/v1alpha1"
 	clientTypes "github.com/tsuru/rpaas-operator/pkg/rpaas/client/types"
@@ -117,6 +118,12 @@ type PurgeCacheArgs struct {
 	PreservePath bool   `json:"preserve_path" form:"preserve_path"`
 }
 
+type Plan struct {
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	Schemas     *osb.Schemas `json:"schemas,omitempty"`
+}
+
 type Flavor struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
@@ -145,7 +152,7 @@ type RpaasManager interface {
 	GetInstanceAddress(ctx context.Context, name string) (string, error)
 	GetInstanceStatus(ctx context.Context, name string) (*nginxv1alpha1.Nginx, PodStatusMap, error)
 	Scale(ctx context.Context, name string, replicas int32) error
-	GetPlans(ctx context.Context) ([]v1alpha1.RpaasPlan, error)
+	GetPlans(ctx context.Context) ([]Plan, error)
 	GetFlavors(ctx context.Context) ([]Flavor, error)
 	BindApp(ctx context.Context, instanceName string, args BindAppArgs) error
 	UnbindApp(ctx context.Context, instanceName, appName string) error

--- a/internal/pkg/rpaas/manager_test.go
+++ b/internal/pkg/rpaas/manager_test.go
@@ -1,0 +1,161 @@
+// Copyright 2019 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package rpaas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateArgs_Flavors(t *testing.T) {
+	tests := []struct {
+		args CreateArgs
+		want []string
+	}{
+		{},
+		{
+			args: CreateArgs{
+				Parameters: map[string]interface{}{
+					"flavors": map[string]interface{}{
+						"0": "strawberry",
+						"1": "blueberry",
+					},
+				},
+			},
+			want: []string{"strawberry", "blueberry"},
+		},
+		{
+			args: CreateArgs{
+				Tags: []string{"flavor:banana"},
+			},
+			want: []string{"banana"},
+		},
+		{
+			args: CreateArgs{
+				Parameters: map[string]interface{}{
+					"flavors": map[string]interface{}{
+						"0": "strawberry",
+						"1": "blueberry",
+					},
+				},
+				Tags: []string{"flavors=banana"},
+			},
+			want: []string{"strawberry", "blueberry"},
+		},
+		{
+			args: CreateArgs{
+				Tags: []string{"flavor:strawberry,blueberry"},
+			},
+			want: []string{"strawberry", "blueberry"},
+		},
+		{
+			args: CreateArgs{
+				Tags: []string{"flavors:strawberry,blueberry"},
+			},
+			want: []string{"strawberry", "blueberry"},
+		},
+		{
+			args: CreateArgs{
+				Tags: []string{"flavor=strawberry,blueberry"},
+			},
+			want: []string{"strawberry", "blueberry"},
+		},
+		{
+			args: CreateArgs{
+				Tags: []string{"flavors=strawberry,blueberry"},
+			},
+			want: []string{"strawberry", "blueberry"},
+		},
+		{
+			args: CreateArgs{
+				Tags: []string{"flavor:banana", "flavors=strawberry,blueberry"},
+			},
+			want: []string{"banana"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			have := tt.args.Flavors()
+			assert.Equal(t, tt.want, have)
+		})
+	}
+}
+
+func TestUpdateInstanceArgs_Flavors(t *testing.T) {
+	tests := []struct {
+		args UpdateInstanceArgs
+		want []string
+	}{
+		{},
+		{
+			args: UpdateInstanceArgs{
+				Parameters: map[string]interface{}{
+					"flavors": map[string]interface{}{
+						"0": "strawberry",
+						"1": "blueberry",
+					},
+				},
+			},
+			want: []string{"strawberry", "blueberry"},
+		},
+		{
+			args: UpdateInstanceArgs{
+				Tags: []string{"flavor:banana"},
+			},
+			want: []string{"banana"},
+		},
+		{
+			args: UpdateInstanceArgs{
+				Parameters: map[string]interface{}{
+					"flavors": map[string]interface{}{
+						"0": "strawberry",
+						"1": "blueberry",
+					},
+				},
+				Tags: []string{"flavors=banana"},
+			},
+			want: []string{"strawberry", "blueberry"},
+		},
+		{
+			args: UpdateInstanceArgs{
+				Tags: []string{"flavor:strawberry,blueberry"},
+			},
+			want: []string{"strawberry", "blueberry"},
+		},
+		{
+			args: UpdateInstanceArgs{
+				Tags: []string{"flavors:strawberry,blueberry"},
+			},
+			want: []string{"strawberry", "blueberry"},
+		},
+		{
+			args: UpdateInstanceArgs{
+				Tags: []string{"flavor=strawberry,blueberry"},
+			},
+			want: []string{"strawberry", "blueberry"},
+		},
+		{
+			args: UpdateInstanceArgs{
+				Tags: []string{"flavors=strawberry,blueberry"},
+			},
+			want: []string{"strawberry", "blueberry"},
+		},
+		{
+			args: UpdateInstanceArgs{
+				Tags: []string{"flavor:banana", "flavors=strawberry,blueberry"},
+			},
+			want: []string{"banana"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			have := tt.args.Flavors()
+			assert.Equal(t, tt.want, have)
+		})
+	}
+}

--- a/internal/pkg/rpaas/manager_test.go
+++ b/internal/pkg/rpaas/manager_test.go
@@ -85,6 +85,84 @@ func TestCreateArgs_Flavors(t *testing.T) {
 	}
 }
 
+func TestCreateArgs_IP(t *testing.T) {
+	tests := []struct {
+		args CreateArgs
+		want string
+	}{
+		{},
+		{
+			args: CreateArgs{
+				Parameters: map[string]interface{}{"ip": "7.7.7.7"},
+			},
+			want: "7.7.7.7",
+		},
+		{
+			args: CreateArgs{
+				Parameters: map[string]interface{}{"ip": []string{"not valid"}},
+			},
+		},
+		{
+			args: CreateArgs{Tags: []string{"ip:7.7.7.7"}},
+			want: "7.7.7.7",
+		},
+		{
+			args: CreateArgs{Tags: []string{"ip=7.7.7.7"}},
+			want: "7.7.7.7",
+		},
+		{
+			args: CreateArgs{Tags: []string{"ip:6.6.6.6", "ip=7.7.7.7"}},
+			want: "6.6.6.6",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			have := tt.args.IP()
+			assert.Equal(t, tt.want, have)
+		})
+	}
+}
+
+func TestCreateArgs_PlanOverride(t *testing.T) {
+	tests := []struct {
+		args CreateArgs
+		want string
+	}{
+		{},
+		{
+			args: CreateArgs{
+				Parameters: map[string]interface{}{"plan-override": `{"image": "nginx:alpine"}`},
+			},
+			want: `{"image": "nginx:alpine"}`,
+		},
+		{
+			args: CreateArgs{
+				Parameters: map[string]interface{}{"plan-override": []string{"not valid"}},
+			},
+		},
+		{
+			args: CreateArgs{Tags: []string{`plan-override:{"config": {"cacheEnabled": false}}`}},
+			want: `{"config": {"cacheEnabled": false}}`,
+		},
+		{
+			args: CreateArgs{Tags: []string{`plan-override={"config": {"cacheEnabled": false}}`}},
+			want: `{"config": {"cacheEnabled": false}}`,
+		},
+		{
+			args: CreateArgs{Tags: []string{`plan-override={"image": "nginx:alpine"}`, `plan-override:{"config": {"cacheEnabled": false}}`}},
+			want: `{"image": "nginx:alpine"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			have := tt.args.PlanOverride()
+			assert.Equal(t, tt.want, have)
+		})
+	}
+}
+
 func TestUpdateInstanceArgs_Flavors(t *testing.T) {
 	tests := []struct {
 		args UpdateInstanceArgs
@@ -155,6 +233,88 @@ func TestUpdateInstanceArgs_Flavors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
 			have := tt.args.Flavors()
+			assert.Equal(t, tt.want, have)
+		})
+	}
+}
+
+func TestUpdateInstanceArgs_IP(t *testing.T) {
+	tests := []struct {
+		args UpdateInstanceArgs
+		want string
+	}{
+		{},
+		{
+			args: UpdateInstanceArgs{
+				Parameters: map[string]interface{}{
+					"ip": "7.7.7.7",
+				},
+			},
+			want: "7.7.7.7",
+		},
+		{
+			args: UpdateInstanceArgs{
+				Parameters: map[string]interface{}{
+					"ip": []string{"not valid"},
+				},
+			},
+		},
+		{
+			args: UpdateInstanceArgs{Tags: []string{"ip:7.7.7.7"}},
+			want: "7.7.7.7",
+		},
+		{
+			args: UpdateInstanceArgs{Tags: []string{"ip=7.7.7.7"}},
+			want: "7.7.7.7",
+		},
+		{
+			args: UpdateInstanceArgs{Tags: []string{"ip:6.6.6.6", "ip=7.7.7.7"}},
+			want: "6.6.6.6",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			have := tt.args.IP()
+			assert.Equal(t, tt.want, have)
+		})
+	}
+}
+
+func TestUpdateInstanceArgs_PlanOverride(t *testing.T) {
+	tests := []struct {
+		args UpdateInstanceArgs
+		want string
+	}{
+		{},
+		{
+			args: UpdateInstanceArgs{
+				Parameters: map[string]interface{}{"plan-override": `{"image": "nginx:alpine"}`},
+			},
+			want: `{"image": "nginx:alpine"}`,
+		},
+		{
+			args: UpdateInstanceArgs{
+				Parameters: map[string]interface{}{"plan-override": []string{"not valid"}},
+			},
+		},
+		{
+			args: UpdateInstanceArgs{Tags: []string{`plan-override:{"config": {"cacheEnabled": false}}`}},
+			want: `{"config": {"cacheEnabled": false}}`,
+		},
+		{
+			args: UpdateInstanceArgs{Tags: []string{`plan-override={"config": {"cacheEnabled": false}}`}},
+			want: `{"config": {"cacheEnabled": false}}`,
+		},
+		{
+			args: UpdateInstanceArgs{Tags: []string{`plan-override={"image": "nginx:alpine"}`, `plan-override:{"config": {"cacheEnabled": false}}`}},
+			want: `{"image": "nginx:alpine"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			have := tt.args.PlanOverride()
 			assert.Equal(t, tt.want, have)
 		})
 	}


### PR DESCRIPTION
Since https://github.com/tsuru/tsuru/pull/2380, all Tsuru services will be notified about the plan parameters used on instance creation and/or update. This means that RPaaS instance parameters (such as flavors, IP and plan-override) can be set using the `tsuru` command line directly, e.g.

```bash
tsuru service-instance-add rpaasv2 my-instance --plan-param flavors=banana --plan-param 'plan-override={"image": "tsuru/nginx-tsuru:latest"}'
```

This PR contains the changes according to Tsuru Service API spec to make this possible.