### PR TITLE
feat: support to create loadbalancer with a custom name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,16 +29,17 @@ const (
 )
 
 type RpaasConfig struct {
-	ServiceName     string                     `json:"service-name"`
-	APIUsername     string                     `json:"api-username"`
-	APIPassword     string                     `json:"api-password"`
-	TLSCertificate  string                     `json:"tls-certificate"`
-	TLSKey          string                     `json:"tls-key"`
-	DefaultAffinity *corev1.Affinity           `json:"default-affinity"`
-	TeamAffinity    map[string]corev1.Affinity `json:"team-affinity"`
-	SyncInterval    time.Duration              `json:"sync-interval"`
-	PortRangeMin    int32                      `json:"port-range-min"`
-	PortRangeMax    int32                      `json:"port-range-max"`
+	ServiceName              string                     `json:"service-name"`
+	APIUsername              string                     `json:"api-username"`
+	APIPassword              string                     `json:"api-password"`
+	TLSCertificate           string                     `json:"tls-certificate"`
+	TLSKey                   string                     `json:"tls-key"`
+	DefaultAffinity          *corev1.Affinity           `json:"default-affinity"`
+	TeamAffinity             map[string]corev1.Affinity `json:"team-affinity"`
+	SyncInterval             time.Duration              `json:"sync-interval"`
+	PortRangeMin             int32                      `json:"port-range-min"`
+	PortRangeMax             int32                      `json:"port-range-max"`
+	LoadBalancerNameLabelKey string                     `json:"loadbalancer-name-label-key"`
 }
 
 var rpaasConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -166,6 +166,18 @@ team-affinity:
 				},
 			},
 		},
+		{
+			config: `
+loadbalancer-name-label-key: my.cloudprovider.example.com/lb-name
+`,
+			expected: RpaasConfig{
+				ServiceName:              "rpaasv2",
+				SyncInterval:             5 * time.Minute,
+				PortRangeMin:             20000,
+				PortRangeMax:             30000,
+				LoadBalancerNameLabelKey: "my.cloudprovider.example.com/lb-name",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/rpaas/k8s.go
+++ b/internal/pkg/rpaas/k8s.go
@@ -1690,20 +1690,18 @@ func buildServiceInstanceParametersForPlan(flavors []Flavor) interface{} {
 		},
 		"ip": map[string]interface{}{
 			"type":        "string",
-			"description": "IP address that will be assigned to load balancer.\nExamples:\n\tip=192.168.15.10",
+			"description": "IP address that will be assigned to load balancer. Example: ip=192.168.15.10.\n",
 		},
 		"plan-override": map[string]interface{}{
 			"type":        "object",
-			"description": "Allows an instance to change its plan parameters to specific ones.\nExamples:\n\tplan-override={\"config\": {\"cacheEnabled\": false}}\n\tplan-override={\"image\": \"tsuru/nginx:latest\"}",
+			"description": "Allows an instance to change its plan parameters to specific ones. Examples: plan-override={\"config\": {\"cacheEnabled\": false}}; plan-override={\"image\": \"tsuru/nginx:latest\"}.\n",
 		},
 	}
 
 	if config.Get().LoadBalancerNameLabelKey != "" {
 		planParameters["lb-name"] = map[string]interface{}{
-			"type": "string",
-			"description": `Custom domain address (e.g. following RFC 1035) assingned to instance's load balancer.
-Example:
-    lb-name=my-instance.internal.subdomain.example`,
+			"type":        "string",
+			"description": "Custom domain address (e.g. following RFC 1035) assingned to instance's load balancer. Example: lb-name=my-instance.internal.subdomain.example.\n",
 		}
 	}
 
@@ -1722,20 +1720,20 @@ Example:
 
 func formatFlavorsDescription(flavors []Flavor) string {
 	var sb strings.Builder
-	sb.WriteString("Provides a self-contained set of features that can be enabled on this plan.\n")
+	sb.WriteString("Provides a self-contained set of features that can be enabled on this plan. Example: flavors=flavor-a,flavor-b.\n")
 
 	if len(flavors) == 0 {
 		return sb.String()
 	}
 
-	sb.WriteString("\n")
-	sb.WriteString("Supported flavors:")
+	sb.WriteString("  supported flavors:")
 	for _, f := range flavors {
 		sb.WriteString("\n")
-		sb.WriteString(fmt.Sprintf("\t- name: %s\n", f.Name))
-		sb.WriteString(fmt.Sprintf("\t  description: %s", f.Description))
+		sb.WriteString(fmt.Sprintf("    - name: %s\n", f.Name))
+		sb.WriteString(fmt.Sprintf("      description: %s", f.Description))
 	}
 
+	sb.WriteString("\n")
 	return sb.String()
 }
 

--- a/internal/pkg/rpaas/k8s.go
+++ b/internal/pkg/rpaas/k8s.go
@@ -1679,28 +1679,39 @@ func (m *k8sRpaasManager) getErrorsForPod(ctx context.Context, pod *corev1.Pod) 
 }
 
 func buildServiceInstanceParametersForPlan(flavors []Flavor) interface{} {
-	return map[string]interface{}{
-		"$id":     "https://example.com/schema.json",
-		"$schema": "https://json-schema.org/draft-07/schema#",
-		"type":    "object",
-		"properties": map[string]interface{}{
-			"flavors": map[string]interface{}{
-				"type": "array",
-				"items": map[string]interface{}{
-					"$ref": "#/definitions/flavor",
-				},
-				"description": formatFlavorsDescription(flavors),
-				"enum":        flavorNames(flavors),
+	planParameters := map[string]interface{}{
+		"flavors": map[string]interface{}{
+			"type": "array",
+			"items": map[string]interface{}{
+				"$ref": "#/definitions/flavor",
 			},
-			"ip": map[string]interface{}{
-				"type":        "string",
-				"description": "IP address that will be assigned to load balancer.\nExamples:\n\tip=192.168.15.10",
-			},
-			"plan-override": map[string]interface{}{
-				"type":        "object",
-				"description": "Allows an instance to change its plan parameters to specific ones.\nExamples:\n\tplan-override={\"config\": {\"cacheEnabled\": false}}\n\tplan-override={\"image\": \"tsuru/nginx:latest\"}",
-			},
+			"description": formatFlavorsDescription(flavors),
+			"enum":        flavorNames(flavors),
 		},
+		"ip": map[string]interface{}{
+			"type":        "string",
+			"description": "IP address that will be assigned to load balancer.\nExamples:\n\tip=192.168.15.10",
+		},
+		"plan-override": map[string]interface{}{
+			"type":        "object",
+			"description": "Allows an instance to change its plan parameters to specific ones.\nExamples:\n\tplan-override={\"config\": {\"cacheEnabled\": false}}\n\tplan-override={\"image\": \"tsuru/nginx:latest\"}",
+		},
+	}
+
+	if config.Get().LoadBalancerNameLabelKey != "" {
+		planParameters["lb-name"] = map[string]interface{}{
+			"type": "string",
+			"description": `Custom domain address (e.g. following RFC 1035) assingned to instance's load balancer.
+Example:
+    lb-name=my-instance.internal.subdomain.example`,
+		}
+	}
+
+	return map[string]interface{}{
+		"$id":        "https://example.com/schema.json",
+		"$schema":    "https://json-schema.org/draft-07/schema#",
+		"type":       "object",
+		"properties": planParameters,
 		"definitions": map[string]interface{}{
 			"flavor": map[string]interface{}{
 				"type": "string",

--- a/internal/pkg/rpaas/k8s_test.go
+++ b/internal/pkg/rpaas/k8s_test.go
@@ -4031,22 +4031,24 @@ func Test_k8sRpaasManager_GetPlans(t *testing.T) {
 				"items": map[string]interface{}{
 					"$ref": "#/definitions/flavor",
 				},
-				"description": "Provides a self-contained set of features that can be enabled on this plan.\n\nSupported flavors:\n\t- name: flavor-a\n\t  description: description about flavor-a",
-				"enum":        []string{"flavor-a"},
+				"description": `Provides a self-contained set of features that can be enabled on this plan. Example: flavors=flavor-a,flavor-b.
+  supported flavors:
+    - name: flavor-a
+      description: description about flavor-a
+`,
+				"enum": []string{"flavor-a"},
 			},
 			"ip": map[string]interface{}{
 				"type":        "string",
-				"description": "IP address that will be assigned to load balancer.\nExamples:\n\tip=192.168.15.10",
+				"description": "IP address that will be assigned to load balancer. Example: ip=192.168.15.10.\n",
 			},
 			"plan-override": map[string]interface{}{
 				"type":        "object",
-				"description": "Allows an instance to change its plan parameters to specific ones.\nExamples:\n\tplan-override={\"config\": {\"cacheEnabled\": false}}\n\tplan-override={\"image\": \"tsuru/nginx:latest\"}",
+				"description": "Allows an instance to change its plan parameters to specific ones. Examples: plan-override={\"config\": {\"cacheEnabled\": false}}; plan-override={\"image\": \"tsuru/nginx:latest\"}.\n",
 			},
 			"lb-name": map[string]interface{}{
-				"type": "string",
-				"description": `Custom domain address (e.g. following RFC 1035) assingned to instance's load balancer.
-Example:
-    lb-name=my-instance.internal.subdomain.example`,
+				"type":        "string",
+				"description": "Custom domain address (e.g. following RFC 1035) assingned to instance's load balancer. Example: lb-name=my-instance.internal.subdomain.example.\n",
 			},
 		},
 		"definitions": map[string]interface{}{

--- a/internal/pkg/rpaas/k8s_test.go
+++ b/internal/pkg/rpaas/k8s_test.go
@@ -3045,11 +3045,65 @@ func Test_k8sRpaasManager_CreateInstance(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "with load balancer name",
+			args: CreateArgs{Name: "r1", Team: "t1", Parameters: map[string]interface{}{"lb-name": "my-example.example"}},
+			expected: v1alpha1.RpaasInstance{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "RpaasInstance",
+					APIVersion: "extensions.tsuru.io/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "r1",
+					Namespace:       "rpaasv2",
+					ResourceVersion: "1",
+					Annotations: map[string]string{
+						"rpaas.extensions.tsuru.io/description": "",
+						"rpaas.extensions.tsuru.io/tags":        "",
+						"rpaas.extensions.tsuru.io/team-owner":  "t1",
+					},
+					Labels: map[string]string{
+						"rpaas.extensions.tsuru.io/service-name":  "rpaasv2",
+						"rpaas.extensions.tsuru.io/instance-name": "r1",
+						"rpaas.extensions.tsuru.io/team-owner":    "t1",
+						"rpaas_service":                           "rpaasv2",
+						"rpaas_instance":                          "r1",
+					},
+				},
+				Spec: v1alpha1.RpaasInstanceSpec{
+					Replicas: &one,
+					PlanName: "plan1",
+					Service: &nginxv1alpha1.NginxService{
+						Type: corev1.ServiceTypeLoadBalancer,
+						Annotations: map[string]string{
+							"cloudprovider.example/lb-name": "my-example.example",
+						},
+						Labels: map[string]string{
+							"rpaas.extensions.tsuru.io/service-name":  "rpaasv2",
+							"rpaas.extensions.tsuru.io/instance-name": "r1",
+							"rpaas.extensions.tsuru.io/team-owner":    "t1",
+							"rpaas_service":                           "rpaasv2",
+							"rpaas_instance":                          "r1",
+						},
+					},
+					PodTemplate: nginxv1alpha1.NginxPodTemplateSpec{
+						Labels: map[string]string{
+							"rpaas.extensions.tsuru.io/service-name":  "rpaasv2",
+							"rpaas.extensions.tsuru.io/instance-name": "r1",
+							"rpaas.extensions.tsuru.io/team-owner":    "t1",
+							"rpaas_service":                           "rpaasv2",
+							"rpaas_instance":                          "r1",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			baseConfig := config.RpaasConfig{
-				ServiceName: "rpaasv2",
+				ServiceName:              "rpaasv2",
+				LoadBalancerNameLabelKey: "cloudprovider.example/lb-name",
 				TeamAffinity: map[string]corev1.Affinity{
 					"team-one": {
 						NodeAffinity: &corev1.NodeAffinity{
@@ -3090,6 +3144,10 @@ func Test_k8sRpaasManager_CreateInstance(t *testing.T) {
 }
 
 func Test_k8sRpaasManager_UpdateInstance(t *testing.T) {
+	cfg := config.Get()
+	defer func() { config.Set(cfg) }()
+	config.Set(config.RpaasConfig{LoadBalancerNameLabelKey: "cloudprovider.example/lb-name"})
+
 	instance1 := newEmptyRpaasInstance()
 	instance1.Name = "instance1"
 	instance1.Labels = labelsForRpaasInstance(instance1.Name)
@@ -3158,6 +3216,9 @@ func Test_k8sRpaasManager_UpdateInstance(t *testing.T) {
 				Plan:        "plan2",
 				Tags:        []string{"tag3", "tag4", "tag5", `plan-override={"image": "my.registry.test/nginx:latest"}`},
 				Team:        "team-two",
+				Parameters: map[string]interface{}{
+					"lb-name": "my-instance.example",
+				},
 			},
 			assertion: func(t *testing.T, err error, instance *v1alpha1.RpaasInstance) {
 				require.NoError(t, err)
@@ -3173,6 +3234,7 @@ func Test_k8sRpaasManager_UpdateInstance(t *testing.T) {
 				assert.Equal(t, "v1", instance.Spec.PodTemplate.Labels["pod-label-1"])
 				assert.Equal(t, "team-two", instance.Spec.PodTemplate.Labels["rpaas.extensions.tsuru.io/team-owner"])
 				assert.Equal(t, &v1alpha1.RpaasPlanSpec{Image: "my.registry.test/nginx:latest"}, instance.Spec.PlanTemplate)
+				assert.Equal(t, instance.Spec.Service.Annotations["cloudprovider.example/lb-name"], "my-instance.example")
 			},
 		},
 	}

--- a/internal/pkg/rpaas/manager.go
+++ b/internal/pkg/rpaas/manager.go
@@ -98,6 +98,10 @@ func (args CreateArgs) IP() string {
 	return getIP(args.Parameters, args.Tags)
 }
 
+func (args CreateArgs) LoadBalancerName() string {
+	return getLoadBalancerName(args.Parameters)
+}
+
 func (args CreateArgs) PlanOverride() string {
 	return getPlanOverride(args.Parameters, args.Tags)
 }
@@ -116,6 +120,10 @@ func (args UpdateInstanceArgs) Flavors() []string {
 
 func (args UpdateInstanceArgs) IP() string {
 	return getIP(args.Parameters, args.Tags)
+}
+
+func (args UpdateInstanceArgs) LoadBalancerName() string {
+	return getLoadBalancerName(args.Parameters)
 }
 
 func (args UpdateInstanceArgs) PlanOverride() string {
@@ -278,6 +286,18 @@ func legacyGetPlanOverride(tags []string) string {
 	}
 
 	return values[0]
+}
+
+func getLoadBalancerName(params map[string]interface{}) string {
+	p, found := params["lb-name"]
+	if !found {
+		return ""
+	}
+
+	if lbName, ok := p.(string); ok {
+		return lbName
+	}
+	return ""
 }
 
 func extractTagValues(prefixes, tags []string) []string {


### PR DESCRIPTION
Several cloud provider support to creating a load balancer with custom name based on annotation on Service. This PR implements the changes to support that on RPaaS.

To use that, you must set the cloud provider specific label key on RpaaS config:
```
$ cat rpaas.yaml
...
loadbalancer-name-label-key: my.cloudprovider.example/loadbalancer-name
```

And set the desired load balancer name when creating (or updating) a service instance through Tsuru:

```
$ tsuru service-instance-add ... --plan-param lb-name=my-instance.domain.example
``` 