### PR TITLE
feat(openapi): docs for tsuro bind and bind-app

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -181,7 +181,7 @@ paths:
 
   /resources/{instance}/bind-app:
     parameters:
-      - name: name
+      - name: instance
         in: path
         description: Instance name
         required: true
@@ -227,7 +227,7 @@ paths:
 
   /resources/{instance}/bind:
     parameters:
-      - name: name
+      - name: instance
         in: path
         description: Instance name
         required: true
@@ -235,22 +235,26 @@ paths:
           type: string
 
       post:
+        operationId: BindInstance
+        deprecated: true
         summary: Bind Unit
-        description: The service endpoint binds a unit to the service instance
-        tags:
-          - rpaas
-        responses:
-          '201':
-            description: Unit successfully bound to the service instance
-
-      delete:
-        summary: Unbind Unit
-        description: The service endpoint unbinds the unit from the service instance
+        description: Not used, just to follow Tsuru Service API spec
         tags:
           - rpaas
         responses:
           '200':
-            description: Unit successfully unbound from service instance
+            description: Nothing happens
+
+      delete:
+        operationId: UnbindInstance
+        deprecated: true
+        summary: Unbind Unit
+        description: Not used, just to follow Tsuru Service API spec
+        tags:
+          - rpaas
+        responses:
+          '200':
+            description: Nothing happens
 
   /resources/{instance}/info:
     get:
@@ -453,12 +457,24 @@ components:
       properties:
         app-name:
           type: string
+          example: app1
         app-host:
           type: string
+          example: app1.tsuru.example.com
         user:
           type: string
         eventid:
           type: string
+        app-hosts:
+          type: array
+          items:
+            type: string
+            example: app1.tsuru.example.com
+        app-internal-hosts:
+          type: array
+          items:
+            type: string
+            example: localService.namespace
 
     Block:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -179,6 +179,79 @@ paths:
         '204':
           description: Instance is up and running
 
+  /resources/{instance}/bind-app:
+    parameters:
+      - name: name
+        in: path
+        description: Instance name
+        required: true
+        schema:
+          type: string
+
+    post:
+      summary: Binds the app to the rpaas instance
+      description: This endpoint is part of Tsuru Service API.
+      operationId: BindApp
+      tags:
+        - rpaas
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BindApp'
+      responses:
+        '201':
+          description: App successfully bound to the rpaas instance
+        '404':
+          description: rpaas instance does not exist
+        '412':
+          description: rpaas instance not ready
+
+    delete:
+      summary: Unbinds the app from the rpaas instance
+      description: This endpoint is part of Tsuru Service API.
+      operationId: UnbindApp
+      tags:
+        - rpaas
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/BindApp'
+      responses:
+        '200':
+          description: App successfully unbound from rpaas instance
+        '404':
+          description: rpaas instance does not exist
+
+  /resources/{instance}/bind:
+    parameters:
+      - name: name
+        in: path
+        description: Instance name
+        required: true
+        schema:
+          type: string
+
+      post:
+        summary: Bind Unit
+        description: The service endpoint binds a unit to the service instance
+        tags:
+          - rpaas
+        responses:
+          '201':
+            description: Unit successfully bound to the service instance
+
+      delete:
+        summary: Unbind Unit
+        description: The service endpoint unbinds the unit from the service instance
+        tags:
+          - rpaas
+        responses:
+          '200':
+            description: Unit successfully unbound from service instance
+
   /resources/{instance}/info:
     get:
       summary: Get a summary informations about an instance
@@ -374,7 +447,19 @@ components:
           example: 99
           minimum: 0
           maximum: 100
-  
+
+    BindApp:
+      type: object
+      properties:
+        app-name:
+          type: string
+        app-host:
+          type: string
+        user:
+          type: string
+        eventid:
+          type: string
+
     Block:
       type: object
       properties:


### PR DESCRIPTION
I added openapi docs for some routes that were missing
```
POST: /resources/:instance/bind-app
DELETE: /resources/:instance/bind-app
POST: /resources/:instance/bind
DELETE: /resources/:instance/bind
```

I'm not familiar with openapi, so if there's anything i did wrong or should be improved, please let me know!

Part of #39