### PR TITLE
refactor: start controller-runtime manager

### DIFF
--- a/cmd/purger/main.go
+++ b/cmd/purger/main.go
@@ -54,6 +54,10 @@ func main() {
 		log.Fatalf("could not create Purge API: %v", err)
 	}
 
+	go func() {
+		mgr.Start(a.Shutdown)
+	}()
+
 	if err := a.Start(); err != nil {
 		log.Fatalf("could not start the Purge API server: %v", err)
 	}

--- a/internal/pkg/rpaas/nginx/manager.go
+++ b/internal/pkg/rpaas/nginx/manager.go
@@ -82,7 +82,7 @@ func (m NginxManager) purgeRequest(host, path string, port int32, headers map[st
 		return NginxError{Msg: errorMessage}
 	}
 	if resp.StatusCode != http.StatusOK {
-		errorMessage := fmt.Sprintf("cannot purge nginx cache - unexpected response from nginx server: %v", resp)
+		errorMessage := fmt.Sprintf("cannot purge nginx cache - unexpected response from nginx server: %d", resp.StatusCode)
 		logrus.Error(errorMessage)
 		return NginxError{Msg: errorMessage}
 	}

--- a/internal/purge/cache.go
+++ b/internal/purge/cache.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tsuru/rpaas-operator/internal/pkg/rpaas"
 )
 
-func (p *purge) cachePurge(c echo.Context) error {
+func (p *PurgeAPI) cachePurge(c echo.Context) error {
 	if c.Request().ContentLength == 0 {
 		return echo.NewHTTPError(http.StatusBadRequest, "Request body can't be empty")
 	}
@@ -37,7 +37,7 @@ func (p *purge) cachePurge(c echo.Context) error {
 	return c.JSON(http.StatusOK, rpaas.PurgeCacheBulkResult{Path: args.Path, InstancesPurged: count})
 }
 
-func (p *purge) cachePurgeBulk(c echo.Context) error {
+func (p *PurgeAPI) cachePurgeBulk(c echo.Context) error {
 	if c.Request().ContentLength == 0 {
 		return echo.NewHTTPError(http.StatusBadRequest, "Request body can't be empty")
 	}
@@ -70,7 +70,7 @@ func (p *purge) cachePurgeBulk(c echo.Context) error {
 	return c.JSON(status, results)
 }
 
-func (p *purge) PurgeCache(ctx context.Context, name string, args rpaas.PurgeCacheArgs) (int, error) {
+func (p *PurgeAPI) PurgeCache(ctx context.Context, name string, args rpaas.PurgeCacheArgs) (int, error) {
 	if args.Path == "" {
 		return 0, rpaas.ValidationError{Msg: "path is required"}
 	}


### PR DESCRIPTION
We need an active cache for listing pods, starting the manager makes that happens.