### PR TITLE
Purge fixes

### DIFF
--- a/internal/pkg/rpaas/nginx/manager.go
+++ b/internal/pkg/rpaas/nginx/manager.go
@@ -7,6 +7,7 @@ package nginx
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -58,7 +59,11 @@ func (m NginxManager) PurgeCache(host, purgePath string, port int32, preservePat
 		headers := map[string]string{"Accept-Encoding": encoding}
 
 		if preservePath {
-			path := fmt.Sprintf("%s%s", defaultPurgeLocation, purgePath)
+			separator := "/"
+			if strings.HasPrefix(purgePath, "/") {
+				separator = ""
+			}
+			path := fmt.Sprintf("%s%s%s", defaultPurgeLocation, separator, purgePath)
 			if err := m.purgeRequest(host, path, port, headers); err != nil {
 				return err
 			}

--- a/internal/pkg/rpaas/nginx/manager.go
+++ b/internal/pkg/rpaas/nginx/manager.go
@@ -86,12 +86,13 @@ func (m NginxManager) purgeRequest(host, path string, port int32, headers map[st
 		logrus.Error(errorMessage)
 		return NginxError{Msg: errorMessage}
 	}
-	if resp.StatusCode != http.StatusOK {
-		errorMessage := fmt.Sprintf("cannot purge nginx cache - unexpected response from nginx server: %d", resp.StatusCode)
-		logrus.Error(errorMessage)
-		return NginxError{Msg: errorMessage}
+	// StatusNotFound is a valid response when nginx does not have the path on its cache.
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNotFound {
+		return nil
 	}
-	return nil
+	errorMessage := fmt.Sprintf("cannot purge nginx cache - unexpected response from nginx server: %d", resp.StatusCode)
+	logrus.Error(errorMessage)
+	return NginxError{Msg: errorMessage}
 }
 
 func (m NginxManager) requestNginx(host, path string, port int32, headers map[string]string) (*http.Response, error) {

--- a/internal/pkg/rpaas/nginx/manager_test.go
+++ b/internal/pkg/rpaas/nginx/manager_test.go
@@ -27,7 +27,7 @@ func TestNginxManager_PurgeCache(t *testing.T) {
 			purgePath:    "/index.html",
 			preservePath: false,
 			assertion: func(t *testing.T, err error) {
-				require.Error(t, err)
+				require.NoError(t, err)
 			},
 			nginxResponse: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusNotFound)
@@ -38,10 +38,21 @@ func TestNginxManager_PurgeCache(t *testing.T) {
 			purgePath:    "/index.html",
 			preservePath: true,
 			assertion: func(t *testing.T, err error) {
-				require.Error(t, err)
+				require.NoError(t, err)
 			},
 			nginxResponse: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusNotFound)
+			},
+		},
+		{
+			description:  "returns not found error when nginx returns 500",
+			purgePath:    "/index.html",
+			preservePath: true,
+			assertion: func(t *testing.T, err error) {
+				require.Error(t, err)
+			},
+			nginxResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
 			},
 		},
 		{

--- a/internal/pkg/rpaas/nginx/manager_test.go
+++ b/internal/pkg/rpaas/nginx/manager_test.go
@@ -60,6 +60,21 @@ func TestNginxManager_PurgeCache(t *testing.T) {
 			},
 		},
 		{
+			description:  "makes a request to /purge/<purgePath> when preservePath is true with custom cache key",
+			purgePath:    "0:desktop:myhostname/some/path/index.html",
+			preservePath: true,
+			assertion: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+			nginxResponse: func(w http.ResponseWriter, r *http.Request) {
+				if r.RequestURI == "/purge/0:desktop:myhostname/some/path/index.html" {
+					w.WriteHeader(http.StatusOK)
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+			},
+		},
+		{
 			description:  "makes a request to /purge/<protocol>/<purgePath> when preservePath is false",
 			purgePath:    "/index.html",
 			preservePath: false,

--- a/internal/purge/cache.go
+++ b/internal/purge/cache.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/tsuru/rpaas-operator/internal/pkg/rpaas"
 )
@@ -79,6 +80,7 @@ func (p *PurgeAPI) PurgeCache(ctx context.Context, name string, args rpaas.Purge
 	if err != nil {
 		return 0, rpaas.NotFoundError{Msg: fmt.Sprintf("Failed to find pods: %v", err)}
 	}
+	logrus.Infof("Found %d pods listening on port %d for instance: %s", len(pods), port, name)
 
 	var purgeErrors error
 	purgeCount := 0
@@ -87,7 +89,7 @@ func (p *PurgeAPI) PurgeCache(ctx context.Context, name string, args rpaas.Purge
 			continue
 		}
 		if err = p.cacheManager.PurgeCache(pod.Address, args.Path, port, args.PreservePath); err != nil {
-			purgeErrors = multierror.Append(purgeErrors, errors.Wrapf(err, "pod %s failed", pod.Address))
+			purgeErrors = multierror.Append(purgeErrors, errors.Wrapf(err, "pod %s:%d failed", pod.Address, port))
 			continue
 		}
 		purgeCount++

--- a/internal/purge/cache_test.go
+++ b/internal/purge/cache_test.go
@@ -56,7 +56,7 @@ func TestCachePurge(t *testing.T) {
 			instance:       "sample-rpaasv2",
 			requestBody:    `{"path":"/index.html","preserve_path":true}`,
 			expectedStatus: http.StatusOK,
-			expectedBody:   `{"path":"/index.html","instances_purged":1,"error":"1 error occurred:\n\t* pod 172.0.2.2 failed: some nginx error\n\n"}`,
+			expectedBody:   `{"path":"/index.html","instances_purged":1,"error":"1 error occurred:\n\t* pod 172.0.2.2:8889 failed: some nginx error\n\n"}`,
 			cacheManager: fakeCacheManager{
 				purgeCacheFunc: func(host, path string, port int32, preservePath bool) error {
 					if host == "172.0.2.2" {
@@ -128,7 +128,7 @@ func TestCachePurgeBulk(t *testing.T) {
 			instance:       "sample-rpaasv2",
 			requestBody:    `[{"path":"/index.html","preserve_path":true},{"path":"/other.html","preserve_path":true}]`,
 			expectedStatus: http.StatusInternalServerError,
-			expectedBody:   `[{"path":"/index.html","instances_purged":2},{"path":"/other.html","instances_purged":1,"error":"1 error occurred:\n\t* pod 172.0.2.2 failed: some nginx error\n\n"}]`,
+			expectedBody:   `[{"path":"/index.html","instances_purged":2},{"path":"/other.html","instances_purged":1,"error":"1 error occurred:\n\t* pod 172.0.2.2:8889 failed: some nginx error\n\n"}]`,
 			cacheManager: fakeCacheManager{
 				purgeCacheFunc: func(host, path string, port int32, preservePath bool) error {
 					if host == "172.0.2.2" && path == "/other.html" {
@@ -192,6 +192,8 @@ func getFakePods() []runtime.Object {
 				{
 					Ports: []apiv1.ContainerPort{
 						{Name: "nginx-metrics", ContainerPort: 8889},
+						{Name: "http", ContainerPort: 8888},
+						{Name: "https", ContainerPort: 8443},
 					},
 				},
 			},
@@ -215,6 +217,8 @@ func getFakePods() []runtime.Object {
 				{
 					Ports: []apiv1.ContainerPort{
 						{Name: "nginx-metrics", ContainerPort: 8889},
+						{Name: "http", ContainerPort: 8888},
+						{Name: "https", ContainerPort: 8443},
 					},
 				},
 			},


### PR DESCRIPTION
- Fix support for custom paths that don't start with `/`.
- 404 is a valid response, meaning that the server does not have that object in its cache.
- Adds some logging to purger code.