### PR TITLE
purger: fix request to purger nginx path and returned purged instances

### DIFF
--- a/internal/pkg/rpaas/k8s.go
+++ b/internal/pkg/rpaas/k8s.go
@@ -990,15 +990,19 @@ func (m *k8sRpaasManager) PurgeCache(ctx context.Context, instanceName string, a
 	port := util.PortByName(nginx.Spec.PodTemplate.Ports, nginxManager.PortNameManagement)
 	var purgeErrors error
 	purgeCount := 0
+	status := false
 	for _, podStatus := range podMap {
 		if !podStatus.Running {
 			continue
 		}
-		if err = m.cacheManager.PurgeCache(podStatus.Address, args.Path, port, args.PreservePath); err != nil {
+		status, err = m.cacheManager.PurgeCache(podStatus.Address, args.Path, port, args.PreservePath)
+		if err != nil {
 			purgeErrors = multierror.Append(purgeErrors, errors.Wrapf(err, "pod %s failed", podStatus.Address))
 			continue
 		}
-		purgeCount++
+		if status {
+			purgeCount++
+		}
 	}
 	return purgeCount, purgeErrors
 }

--- a/internal/pkg/rpaas/manager.go
+++ b/internal/pkg/rpaas/manager.go
@@ -151,7 +151,7 @@ type BindAppArgs struct {
 }
 
 type CacheManager interface {
-	PurgeCache(host, path string, port int32, preservePath bool) error
+	PurgeCache(host, path string, port int32, preservePath bool) (bool, error)
 }
 
 type PurgeCacheArgs struct {

--- a/internal/purge/cache.go
+++ b/internal/purge/cache.go
@@ -84,15 +84,18 @@ func (p *PurgeAPI) PurgeCache(ctx context.Context, name string, args rpaas.Purge
 
 	var purgeErrors error
 	purgeCount := 0
+	status := false
 	for _, pod := range pods {
 		if !pod.Running {
 			continue
 		}
-		if err = p.cacheManager.PurgeCache(pod.Address, args.Path, port, args.PreservePath); err != nil {
+		if status, err = p.cacheManager.PurgeCache(pod.Address, args.Path, port, args.PreservePath); err != nil {
 			purgeErrors = multierror.Append(purgeErrors, errors.Wrapf(err, "pod %s:%d failed", pod.Address, port))
 			continue
 		}
-		purgeCount++
+		if status {
+			purgeCount++
+		}
 	}
 	return purgeCount, purgeErrors
 }


### PR DESCRIPTION
- Fix request to purger nginx path to proper expected cache key -  when preserve path was not set
- Purger now returns successfully purged instances instead total pods - even if no cache key was found