### PR TITLE
feat(api): support custom Nginx log format + log additional headers

### DIFF
--- a/api/v1alpha1/rpaasplan_types.go
+++ b/api/v1alpha1/rpaasplan_types.go
@@ -70,6 +70,11 @@ type NginxConfig struct {
 	CacheSnapshotStorage CacheSnapshotStorage  `json:"cacheSnapshotStorage,omitempty"`
 	CacheSnapshotSync    CacheSnapshotSyncSpec `json:"cacheSnapshotSync,omitempty"`
 
+	LogFormat            string   `json:"logFormat,omitempty"`
+	LogFormatEscape      string   `json:"logFormatEscape,omitempty"`
+	LogFormatName        string   `json:"logFormatName,omitempty"`
+	LogAdditionalHeaders []string `json:"logAdditionalHeaders,omitempty"`
+
 	HTTPListenOptions  string `json:"httpListenOptions,omitempty"`
 	HTTPSListenOptions string `json:"httpsListenOptions,omitempty"`
 

--- a/api/v1alpha1/rpaasplan_types.go
+++ b/api/v1alpha1/rpaasplan_types.go
@@ -70,10 +70,11 @@ type NginxConfig struct {
 	CacheSnapshotStorage CacheSnapshotStorage  `json:"cacheSnapshotStorage,omitempty"`
 	CacheSnapshotSync    CacheSnapshotSyncSpec `json:"cacheSnapshotSync,omitempty"`
 
-	LogFormat            string   `json:"logFormat,omitempty"`
-	LogFormatEscape      string   `json:"logFormatEscape,omitempty"`
-	LogFormatName        string   `json:"logFormatName,omitempty"`
-	LogAdditionalHeaders []string `json:"logAdditionalHeaders,omitempty"`
+	LogFormat            string            `json:"logFormat,omitempty"`
+	LogFormatEscape      string            `json:"logFormatEscape,omitempty"`
+	LogFormatName        string            `json:"logFormatName,omitempty"`
+	LogAdditionalHeaders []string          `json:"logAdditionalHeaders,omitempty"`
+	LogAdditionalFields  map[string]string `json:"logAdditionalFields,omitempty"`
 
 	HTTPListenOptions  string `json:"httpListenOptions,omitempty"`
 	HTTPSListenOptions string `json:"httpsListenOptions,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -250,6 +250,13 @@ func (in *NginxConfig) DeepCopyInto(out *NginxConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.LogAdditionalFields != nil {
+		in, out := &in.LogAdditionalFields, &out.LogAdditionalFields
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.VTSEnabled != nil {
 		in, out := &in.VTSEnabled, &out.VTSEnabled
 		*out = new(bool)

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -245,6 +245,11 @@ func (in *NginxConfig) DeepCopyInto(out *NginxConfig) {
 	}
 	in.CacheSnapshotStorage.DeepCopyInto(&out.CacheSnapshotStorage)
 	in.CacheSnapshotSync.DeepCopyInto(&out.CacheSnapshotSync)
+	if in.LogAdditionalHeaders != nil {
+		in, out := &in.LogAdditionalHeaders, &out.LogAdditionalHeaders
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.VTSEnabled != nil {
 		in, out := &in.VTSEnabled, &out.VTSEnabled
 		*out = new(bool)

--- a/config/crd/bases/extensions.tsuru.io_rpaasflavors.yaml
+++ b/config/crd/bases/extensions.tsuru.io_rpaasflavors.yaml
@@ -446,6 +446,10 @@ spec:
                             type: string
                           httpsListenOptions:
                             type: string
+                          logAdditionalFields:
+                            additionalProperties:
+                              type: string
+                            type: object
                           logAdditionalHeaders:
                             items:
                               type: string

--- a/config/crd/bases/extensions.tsuru.io_rpaasflavors.yaml
+++ b/config/crd/bases/extensions.tsuru.io_rpaasflavors.yaml
@@ -446,6 +446,16 @@ spec:
                             type: string
                           httpsListenOptions:
                             type: string
+                          logAdditionalHeaders:
+                            items:
+                              type: string
+                            type: array
+                          logFormat:
+                            type: string
+                          logFormatEscape:
+                            type: string
+                          logFormatName:
+                            type: string
                           syslogEnabled:
                             type: boolean
                           syslogFacility:

--- a/config/crd/bases/extensions.tsuru.io_rpaasinstances.yaml
+++ b/config/crd/bases/extensions.tsuru.io_rpaasinstances.yaml
@@ -423,6 +423,10 @@ spec:
                         type: string
                       httpsListenOptions:
                         type: string
+                      logAdditionalFields:
+                        additionalProperties:
+                          type: string
+                        type: object
                       logAdditionalHeaders:
                         items:
                           type: string

--- a/config/crd/bases/extensions.tsuru.io_rpaasinstances.yaml
+++ b/config/crd/bases/extensions.tsuru.io_rpaasinstances.yaml
@@ -423,6 +423,16 @@ spec:
                         type: string
                       httpsListenOptions:
                         type: string
+                      logAdditionalHeaders:
+                        items:
+                          type: string
+                        type: array
+                      logFormat:
+                        type: string
+                      logFormatEscape:
+                        type: string
+                      logFormatName:
+                        type: string
                       syslogEnabled:
                         type: boolean
                       syslogFacility:

--- a/config/crd/bases/extensions.tsuru.io_rpaasplans.yaml
+++ b/config/crd/bases/extensions.tsuru.io_rpaasplans.yaml
@@ -104,6 +104,16 @@ spec:
                     type: string
                   httpsListenOptions:
                     type: string
+                  logAdditionalHeaders:
+                    items:
+                      type: string
+                    type: array
+                  logFormat:
+                    type: string
+                  logFormatEscape:
+                    type: string
+                  logFormatName:
+                    type: string
                   syslogEnabled:
                     type: boolean
                   syslogFacility:

--- a/config/crd/bases/extensions.tsuru.io_rpaasplans.yaml
+++ b/config/crd/bases/extensions.tsuru.io_rpaasplans.yaml
@@ -104,6 +104,10 @@ spec:
                     type: string
                   httpsListenOptions:
                     type: string
+                  logAdditionalFields:
+                    additionalProperties:
+                      type: string
+                    type: object
                   logAdditionalHeaders:
                     items:
                       type: string

--- a/internal/pkg/rpaas/nginx/configuration_render.go
+++ b/internal/pkg/rpaas/nginx/configuration_render.go
@@ -296,6 +296,9 @@ http {
     {{- else }}
     log_format {{ $logFormatName }} escape=json
     '{'
+      {{- range $key, $value := $config.LogAdditionalFields }}
+      '"{{ $key }}":"{{ $value }}",'
+      {{- end }}
       '"remote_addr":"${remote_addr}",'
       '"remote_user":"${remote_user}",'
       '"time_local":"${time_local}",'
@@ -361,7 +364,6 @@ http {
     {{- end }}
 
     {{- range $index, $bind := $instance.Spec.Binds }}
-
       {{- if eq $index 0 }}
         upstream rpaas_default_upstream {
           server {{ $bind.Host }};

--- a/internal/pkg/rpaas/nginx/configuration_render.go
+++ b/internal/pkg/rpaas/nginx/configuration_render.go
@@ -289,14 +289,37 @@ http {
     include       mime.types;
     default_type  application/octet-stream;
 
+    {{- $logFormatName := default "rpaasv2" $config.LogFormatName }}
+
+    {{- if $config.LogFormat }}
+    log_format {{ $config.LogFormatName }} {{ with $config.LogFormatEscape}}escape={{ . }}{{ end }} {{ $config.LogFormat }};
+    {{- else }}
+    log_format {{ $logFormatName }} escape=json
+    '{'
+      '"remote_addr":"${remote_addr}",'
+      '"remote_user":"${remote_user}",'
+      '"time_local":"${time_local}",'
+      '"request":"${request}",'
+      '"status":"${status}",'
+      '"body_bytes_sent":"${body_bytes_sent}",'
+      '"referer":"${http_referer}",'
+      '"user_agent":"${http_user_agent}"'
+      {{- range $index, $header := $config.LogAdditionalHeaders }}
+      {{- if not $index }}{{ "\n" }}','{{ end }}
+      {{- $h := lower (replace "-" "_" $header) }}
+      '"header_{{ $h }}":"${http_{{ $h }}}" {{- if lt (add1 $index) (len $config.LogAdditionalHeaders) }},{{ end }}'
+      {{- end }}
+    '}';
+    {{- end }}
+
     {{- if not (boolValue $config.SyslogEnabled) }}
-    access_log /dev/stdout combined;
+    access_log /dev/stdout {{ $logFormatName }};
     error_log  /dev/stderr;
     {{- else }}
     access_log syslog:server={{ $config.SyslogServerAddress }}
         {{- with $config.SyslogFacility }},facility={{ . }}{{ end }}
         {{- with $config.SyslogTag }},tag={{ . }}{{ end}}
-        combined;
+        {{ $logFormatName }};
 
     error_log syslog:server={{ $config.SyslogServerAddress }}
         {{- with $config.SyslogFacility }},facility={{ . }}{{ end }}

--- a/internal/pkg/rpaas/nginx/configuration_render_test.go
+++ b/internal/pkg/rpaas/nginx/configuration_render_test.go
@@ -563,6 +563,26 @@ func TestRpaasConfigurationRenderer_Render(t *testing.T) {
 \s+'}';`, result)
 			},
 		},
+		{
+			name: "with log additional fields",
+			data: ConfigurationData{
+				Config: &v1alpha1.NginxConfig{
+					LogAdditionalFields: map[string]string{
+						"key1":       "Some custom var: ${http_x_foo_bar}",
+						"key2":       "Another custom var: ${host}",
+						"custom_key": "${custom_var}",
+					},
+				},
+				Instance: &v1alpha1.RpaasInstance{},
+			},
+			assertion: func(t *testing.T, result string) {
+				assert.Regexp(t, `\s+'\{'
+\s+'"custom_key":"\$\{custom_var\}",'
+\s+'"key1":"Some custom var: \$\{http_x_foo_bar\}",'
+\s+'"key2":"Another custom var: \$\{host\}",'
+`, result)
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR allows a RpaasInstance to set either a custom log format (log format name, log format, log format escape) or log an additional HTTP header on the Nginx access log.