### PR TITLE
Publish a manifest.json

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,6 +164,30 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow
+    - name: Set VERSION env
+      run: echo "VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+    - name: generate manifest.json
+      env:
+        VERSION: ${{ env.VERSION }}
+      run: |
+        cat >manifest.json <<EOF
+        {
+          "SchemaVersion": "1.0",
+          "Metadata": {
+            "Name": "rpaasv2",
+            "Version": "${VERSION}"
+          },
+          "URLPerPlatform": {
+            "darwin/arm64":  "https://github.com/tsuru/rpaas-operator/releases/download/v${VERSION}/rpaasv2_${VERSION}_Darwin_arm64.tar.gz",
+            "darwin/amd64":  "https://github.com/tsuru/rpaas-operator/releases/download/v${VERSION}/rpaasv2_${VERSION}_Darwin_x86_64.tar.gz",
+            "linux/arm64":   "https://github.com/tsuru/rpaas-operator/releases/download/v${VERSION}/rpaasv2_${VERSION}_Linux_arm64.tar.gz",
+            "linux/386":     "https://github.com/tsuru/rpaas-operator/releases/download/v${VERSION}/rpaasv2_${VERSION}_Linux_i386.tar.gz",
+            "linux/amd64":   "https://github.com/tsuru/rpaas-operator/releases/download/v${VERSION}/rpaasv2_${VERSION}_Linux_x86_64.tar.gz",
+            "windows/386":   "https://github.com/tsuru/rpaas-operator/releases/download/v${VERSION}/rpaasv2_${VERSION}_Windows_i386.zip",
+            "windows/amd64": "https://github.com/tsuru/rpaas-operator/releases/download/v${VERSION}/rpaasv2_${VERSION}_Windows_x86_64.zip"
+          }
+        }
+        EOF
     - uses: actions/setup-go@v2
       with:
         go-version: 1.18

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ tags
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 # rpaas-operator binaries
 bin/
+# manifest.json generated during CI
+manifest.json

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,3 +39,8 @@ archives:
 
 checksum:
   name_template: "checksums.txt"
+
+release:
+  prerelease: auto
+  extra_files:
+    - glob: ./manifest.json


### PR DESCRIPTION
Publishing a `manifest.json` for easy installation from tsuru client (https://github.com/tsuru/tsuru-client/pull/193)

Closes #124 