### PR TITLE
Change usage description for shell command

### DIFF
--- a/cmd/plugin/rpaasv2/cmd/shell.go
+++ b/cmd/plugin/rpaasv2/cmd/shell.go
@@ -17,7 +17,7 @@ import (
 func NewCmdShell() *cli.Command {
 	return &cli.Command{
 		Name:      "shell",
-		Usage:     "Run a command in an instance",
+		Usage:     "Opens a remote shell inside unit",
 		ArgsUsage: "[-p POD] [-c CONTAINER]",
 		Flags: []cli.Flag{
 			&cli.StringFlag{


### PR DESCRIPTION
Command `shell` and `exec` has the same `Usage` description