### PR TITLE
fix: add validation to enforce instance name length limit

### DIFF
--- a/pkg/web/certificate.go
+++ b/pkg/web/certificate.go
@@ -103,6 +103,17 @@ func updateCertManagerRequest(c echo.Context) error {
 		return err
 	}
 
+	const maxInstanceNameLength = 30
+	if len(in.Name) > maxInstanceNameLength {
+		return &rpaas.ValidationError{
+			Msg: fmt.Sprintf(
+				"The instance name '%s' exceeds the limit of %d characters.",
+				in.Name, maxInstanceNameLength,
+			),
+			Internal: nil,
+		}
+	}
+
 	err = manager.UpdateCertManagerRequest(ctx, c.Param("instance"), in)
 	if err != nil {
 		return err

--- a/pkg/web/certificate.go
+++ b/pkg/web/certificate.go
@@ -117,23 +117,18 @@ func updateCertManagerRequest(c echo.Context) error {
 }
 
 func validateCertManagerRequest(in types.CertManager) error {
-	// Set the limits
 	const maxCommonNameLength = 64
-	const domainSuffixLength = 37                                     // Largest suffix identified
-	maxInstanceNameLength := maxCommonNameLength - domainSuffixLength // 64 - 37 = 27
 
-	// Instance name validation
-	if len(in.Name) > maxInstanceNameLength {
+	if len(in.Name) > maxCommonNameLength {
 		return &rpaas.ValidationError{
 			Msg: fmt.Sprintf(
 				"The certificate name '%s' exceeds the limit of %d characters.",
-				in.Name, maxInstanceNameLength,
+				in.Name, maxCommonNameLength,
 			),
 			Internal: nil,
 		}
 	}
 
-	// Validation of the in.DNSNames array
 	for _, dns := range in.DNSNames {
 		if len(dns) > maxCommonNameLength {
 			return &rpaas.ValidationError{

--- a/pkg/web/certificate.go
+++ b/pkg/web/certificate.go
@@ -121,29 +121,18 @@ func validateCertManagerRequest(in types.CertManager) error {
 
 	if len(in.Name) > maxCommonNameLength {
 		return &rpaas.ValidationError{
-			Msg: fmt.Sprintf(
-				"The certificate name '%s' exceeds the limit of %d characters.",
-				in.Name, maxCommonNameLength,
-			),
-			Internal: nil,
+			Msg: fmt.Sprintf("The certificate name '%s' exceeds the limit of %d characters.", in.Name, maxCommonNameLength),
 		}
 	}
 
 	for _, dns := range in.DNSNames {
 		if len(dns) > maxCommonNameLength {
 			return &rpaas.ValidationError{
-				Msg: fmt.Sprintf(
-					"The DNS name '%s' exceeds the limit of %d characters.",
-					dns, maxCommonNameLength,
-				),
-				Internal: nil,
+				Msg: fmt.Sprintf("The DNS name '%s' exceeds the limit of %d characters.", dns, maxCommonNameLength),
 			}
 		}
 		if dns == "" {
-			return &rpaas.ValidationError{
-				Msg:      "DNS names cannot contain empty values.",
-				Internal: nil,
-			}
+			return &rpaas.ValidationError{Msg: "DNS names cannot contain empty values."}
 		}
 	}
 


### PR DESCRIPTION
Implements a validation to enforce instance name length restrictions, ensuring compatibility with the cert-manager requirements.