### PR TITLE
fix: preserving http_origin original value

### DIFF
--- a/pkg/macro/cors.go
+++ b/pkg/macro/cors.go
@@ -35,7 +35,7 @@ if ($request_method = 'OPTIONS') {
 }
 
 if ($cors = "true") {
-    more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+    more_set_headers 'Access-Control-Allow-Origin: $origin_response';
     {{- if .AllowCredentials }}
     more_set_headers 'Access-Control-Allow-Credentials: {{ .AllowCredentials }}';
 	{{- end }}
@@ -45,7 +45,7 @@ if ($cors = "true") {
 }
 
 if ($cors = "trueoptions") {
-    more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+    more_set_headers 'Access-Control-Allow-Origin: $origin_response';
     {{- if .AllowCredentials }}
     more_set_headers 'Access-Control-Allow-Credentials: {{ .AllowCredentials }}';
 	{{- end }}
@@ -68,7 +68,7 @@ func buildCorsOriginRegex(origin string) string {
 		corsOrigins[i] = strings.TrimSpace(origin)
 	}
 	if len(corsOrigins) == 1 && corsOrigins[0] == "*" {
-		return "set $http_origin *;\nset $cors 'true';"
+		return "set $origin_response *;\nset $cors 'true';"
 	}
 
 	var originsRegex string = "if ($http_origin ~* ("
@@ -82,7 +82,7 @@ func buildCorsOriginRegex(origin string) string {
 			}
 		}
 	}
-	originsRegex = originsRegex + ")$ ) { set $cors 'true'; }"
+	originsRegex = originsRegex + ")$ ) {\n    set $origin_response $http_origin;\n    set $cors 'true';\n}"
 	return originsRegex
 }
 

--- a/pkg/macro/cors_test.go
+++ b/pkg/macro/cors_test.go
@@ -41,14 +41,17 @@ func TestExecuteCorsBasic(t *testing.T) {
 		"origins": "http://example.com",
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, `if ($http_origin ~* ((http://example\.com))$ ) { set $cors 'true'; }
+	assert.Equal(t, `if ($http_origin ~* ((http://example\.com))$ ) {
+    set $origin_response $http_origin;
+    set $cors 'true';
+}
 
 if ($request_method = 'OPTIONS') {
 	set $cors ${cors}options;
 }
 
 if ($cors = "true") {
-    more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+    more_set_headers 'Access-Control-Allow-Origin: $origin_response';
     more_set_headers 'Access-Control-Allow-Credentials: true';
     more_set_headers 'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS';
     more_set_headers 'Access-Control-Allow-Headers: Content-Type, Authorization';
@@ -56,7 +59,7 @@ if ($cors = "true") {
 }
 
 if ($cors = "trueoptions") {
-    more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+    more_set_headers 'Access-Control-Allow-Origin: $origin_response';
     more_set_headers 'Access-Control-Allow-Credentials: true';
     more_set_headers 'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS';
     more_set_headers 'Access-Control-Allow-Headers: Content-Type, Authorization';
@@ -73,14 +76,17 @@ func TestExecuteCorsWithArg(t *testing.T) {
 		"http://example.com",
 	}, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, `if ($http_origin ~* ((http://example\.com))$ ) { set $cors 'true'; }
+	assert.Equal(t, `if ($http_origin ~* ((http://example\.com))$ ) {
+    set $origin_response $http_origin;
+    set $cors 'true';
+}
 
 if ($request_method = 'OPTIONS') {
 	set $cors ${cors}options;
 }
 
 if ($cors = "true") {
-    more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+    more_set_headers 'Access-Control-Allow-Origin: $origin_response';
     more_set_headers 'Access-Control-Allow-Credentials: true';
     more_set_headers 'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS';
     more_set_headers 'Access-Control-Allow-Headers: Content-Type, Authorization';
@@ -88,7 +94,7 @@ if ($cors = "true") {
 }
 
 if ($cors = "trueoptions") {
-    more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+    more_set_headers 'Access-Control-Allow-Origin: $origin_response';
     more_set_headers 'Access-Control-Allow-Credentials: true';
     more_set_headers 'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS';
     more_set_headers 'Access-Control-Allow-Headers: Content-Type, Authorization';
@@ -105,7 +111,7 @@ func TestExecuteCorsWildcard(t *testing.T) {
 		"origins": "*",
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, `set $http_origin *;
+	assert.Equal(t, `set $origin_response *;
 set $cors 'true';
 
 if ($request_method = 'OPTIONS') {
@@ -113,7 +119,7 @@ if ($request_method = 'OPTIONS') {
 }
 
 if ($cors = "true") {
-    more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+    more_set_headers 'Access-Control-Allow-Origin: $origin_response';
     more_set_headers 'Access-Control-Allow-Credentials: true';
     more_set_headers 'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS';
     more_set_headers 'Access-Control-Allow-Headers: Content-Type, Authorization';
@@ -121,7 +127,7 @@ if ($cors = "true") {
 }
 
 if ($cors = "trueoptions") {
-    more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+    more_set_headers 'Access-Control-Allow-Origin: $origin_response';
     more_set_headers 'Access-Control-Allow-Credentials: true';
     more_set_headers 'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS';
     more_set_headers 'Access-Control-Allow-Headers: Content-Type, Authorization';
@@ -144,21 +150,24 @@ func TestExecuteCorsFullFeatured(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t,
-		`if ($http_origin ~* ((http://example\.com)|(https://facebook\.com)|(http://[A-Za-z0-9\-]+\.example\.com))$ ) { set $cors 'true'; }
+		`if ($http_origin ~* ((http://example\.com)|(https://facebook\.com)|(http://[A-Za-z0-9\-]+\.example\.com))$ ) {
+    set $origin_response $http_origin;
+    set $cors 'true';
+}
 
 if ($request_method = 'OPTIONS') {
 	set $cors ${cors}options;
 }
 
 if ($cors = "true") {
-    more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+    more_set_headers 'Access-Control-Allow-Origin: $origin_response';
     more_set_headers 'Access-Control-Allow-Methods: GET, POST, PUT, PATCH';
     more_set_headers 'Access-Control-Allow-Headers: Content-Type, Authorization, X-Custom-Header';
     more_set_headers 'Access-Control-Max-Age: 7200';
 }
 
 if ($cors = "trueoptions") {
-    more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+    more_set_headers 'Access-Control-Allow-Origin: $origin_response';
     more_set_headers 'Access-Control-Allow-Methods: GET, POST, PUT, PATCH';
     more_set_headers 'Access-Control-Allow-Headers: Content-Type, Authorization, X-Custom-Header';
     more_set_headers 'Access-Control-Max-Age: 7200';

--- a/pkg/macro/macro_test.go
+++ b/pkg/macro/macro_test.go
@@ -31,14 +31,17 @@ more_set_headers 'Content-Security-Policy: upgrade-insecure-requests';
 more_set_headers 'Strict-Transport-Security: max-age=31536000; includeSubDomains';
 
 location / {
-	if ($http_origin ~* ((facebook\.com)|(google\.com))$ ) { set $cors 'true'; }
+	if ($http_origin ~* ((facebook\.com)|(google\.com))$ ) {
+	    set $origin_response $http_origin;
+	    set $cors 'true';
+	}
 
 	if ($request_method = 'OPTIONS') {
 		set $cors ${cors}options;
 	}
 
 	if ($cors = "true") {
-	    more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+	    more_set_headers 'Access-Control-Allow-Origin: $origin_response';
 	    more_set_headers 'Access-Control-Allow-Credentials: true';
 	    more_set_headers 'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS';
 	    more_set_headers 'Access-Control-Allow-Headers: Content-Type, Authorization';
@@ -46,7 +49,7 @@ location / {
 	}
 
 	if ($cors = "trueoptions") {
-	    more_set_headers 'Access-Control-Allow-Origin: $http_origin';
+	    more_set_headers 'Access-Control-Allow-Origin: $origin_response';
 	    more_set_headers 'Access-Control-Allow-Credentials: true';
 	    more_set_headers 'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS';
 	    more_set_headers 'Access-Control-Allow-Headers: Content-Type, Authorization';


### PR DESCRIPTION
Atualmente a macro de CORS sobrescreve a variável $http_origin quando o domínio é definido como `*`. Fazendo com que o log não reflita a origin original.

A ideia é manter o valor original do http_origin para que o log contenha o valor correto original.