### PR TITLE
feat: update default kubectl image to tsuru/kubectl

### DIFF
--- a/api/v1alpha1/rpaasinstance_types.go
+++ b/api/v1alpha1/rpaasinstance_types.go
@@ -381,7 +381,7 @@ type TLSSessionTicket struct {
 
 	// Image is the container image name used to execute the session ticket
 	// rotation job. It requires either "bash", "base64", "openssl" and "kubectl"
-	// programs be installed into. Defaults to "bitnami/kubectl:latest".
+	// programs be installed into. Defaults to "tsuru/kubectl:latest".
 	// +optional
 	Image string `json:"image,omitempty"`
 }

--- a/api/v1alpha1/rpaasplan_types.go
+++ b/api/v1alpha1/rpaasplan_types.go
@@ -102,7 +102,7 @@ type CacheSnapshotSyncSpec struct {
 	Schedule string `json:"schedule,omitempty"`
 
 	// Container is the image used to sync the containers
-	// default is bitnami/kubectl:latest
+	// default is tsuru/kubectl:latest
 	Image string `json:"image,omitempty"`
 
 	// CmdPodToPVC is used to customize command used to sync memory cache (POD) to persistent storage (PVC)

--- a/config/crd/bases/extensions.tsuru.io_rpaasflavors.yaml
+++ b/config/crd/bases/extensions.tsuru.io_rpaasflavors.yaml
@@ -6672,7 +6672,7 @@ spec:
                             description: |-
                               Image is the container image name used to execute the session ticket
                               rotation job. It requires either "bash", "base64", "openssl" and "kubectl"
-                              programs be installed into. Defaults to "bitnami/kubectl:latest".
+                              programs be installed into. Defaults to "tsuru/kubectl:latest".
                             type: string
                           keepLastKeys:
                             description: |-

--- a/config/crd/bases/extensions.tsuru.io_rpaasinstances.yaml
+++ b/config/crd/bases/extensions.tsuru.io_rpaasinstances.yaml
@@ -6627,7 +6627,7 @@ spec:
                         description: |-
                           Image is the container image name used to execute the session ticket
                           rotation job. It requires either "bash", "base64", "openssl" and "kubectl"
-                          programs be installed into. Defaults to "bitnami/kubectl:latest".
+                          programs be installed into. Defaults to "tsuru/kubectl:latest".
                         type: string
                       keepLastKeys:
                         description: |-

--- a/config/crd/bases/extensions.tsuru.io_rpaasvalidations.yaml
+++ b/config/crd/bases/extensions.tsuru.io_rpaasvalidations.yaml
@@ -6612,7 +6612,7 @@ spec:
                         description: |-
                           Image is the container image name used to execute the session ticket
                           rotation job. It requires either "bash", "base64", "openssl" and "kubectl"
-                          programs be installed into. Defaults to "bitnami/kubectl:latest".
+                          programs be installed into. Defaults to "tsuru/kubectl:latest".
                         type: string
                       keepLastKeys:
                         description: |-

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -61,7 +61,7 @@ const (
 )
 
 var (
-	defaultRotateTLSSessionTicketsImage = "bitnami/kubectl:latest"
+	defaultRotateTLSSessionTicketsImage = "tsuru/kubectl:latest"
 
 	sessionTicketsVolumeName      = "tls-session-tickets"
 	sessionTicketsVolumeMountPath = "/etc/nginx/tickets"


### PR DESCRIPTION
Replaces all references to the default kubectl image from "bitnami/kubectl:latest" to "tsuru/kubectl:latest" in code, CRDs, and documentation. This ensures consistency and aligns with the preferred container image for session ticket rotation and cache sync jobs.